### PR TITLE
Drop support for Java 8

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,16 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        java: ['8', '11']
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11 for x64
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 11
           distribution: 'adopt'
           architecture: x64
       - name: Cache Maven packages

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,12 +17,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        java: ['11', '17']
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11 for x64
+      - name: Set up JDK 11/17 for x64
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java }}
           distribution: 'adopt'
           architecture: x64
       - name: Cache Maven packages

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<artifactId>hakunapi</artifactId>
 	<groupId>fi.nls.hakunapi</groupId>
+	<artifactId>hakunapi</artifactId>
 	<version>0.1.10-SNAPSHOT</version>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>2.6</version>
+					<version>3.3.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.tomcat.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>fi.nls.hakunapi</groupId>
 	<artifactId>hakunapi</artifactId>
+	<groupId>fi.nls.hakunapi</groupId>
 	<version>0.1.10-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
@@ -52,8 +52,10 @@
 		<junit.version>4.13.2</junit.version>
 		<cyclonedx.version>2.7.3</cyclonedx.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<java.version>11</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 	</properties>

--- a/src/hakunapi-core/pom.xml
+++ b/src/hakunapi-core/pom.xml
@@ -8,12 +8,6 @@
     </parent>
     <artifactId>hakunapi-core</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -94,7 +94,7 @@ public class HakunaConfigParser {
         License license = new License();
         license.setName(cfg.getProperty("api.license.name"));
         license.setUrl(cfg.getProperty("api.license.url"));
-        if (license.getName() != null && !license.getName().isEmpty()) {
+        if (license.getName() != null && !license.getName().isBlank()) {
             info.setLicense(license);
         }
 
@@ -179,7 +179,7 @@ public class HakunaConfigParser {
 
     public String getRequired(String key) {
         String value = get(key);
-        if (value == null || value.isEmpty()) {
+        if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("Missing required config property '" + key + "'");
         }
         return value;
@@ -191,7 +191,7 @@ public class HakunaConfigParser {
 
     public String get(String key, String fallback) {
         String value = cfg.getProperty(key);
-        if (value == null || value.isEmpty()) {
+        if (value == null || value.isBlank()) {
             return fallback;
         }
         return value.trim();
@@ -203,7 +203,7 @@ public class HakunaConfigParser {
 
     public String[] getMultiple(String key, String[] fallback) {
         String value = cfg.getProperty(key);
-        if (value == null || value.isEmpty()) {
+        if (value == null || value.isBlank()) {
             return fallback;
         }
         String[] split = value.split(",");
@@ -228,7 +228,7 @@ public class HakunaConfigParser {
     }
 
     protected static int[] getSRIDs(String srid) {
-        if (srid == null || srid.isEmpty()) {
+        if (srid == null || srid.isBlank()) {
             return new int[0];
         }
         return Arrays.stream(srid.split(","))
@@ -569,7 +569,7 @@ public class HakunaConfigParser {
 
     public Map<String, Object> parseMetadata(String p, Path configPath) {
         String metadataProp = get(p + "metadata");
-        if (metadataProp == null || metadataProp.isEmpty()) {
+        if (metadataProp == null || metadataProp.isBlank()) {
             return null;
         }
 

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/GzipOutputStream.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/GzipOutputStream.java
@@ -33,7 +33,7 @@ public class GzipOutputStream extends DeflaterOutputStream {
                 0, // MTIME3
                 0, // MTIME4
                 0, // XFL
-                0  // OS
+                (byte) 255 // OS, changed from 0 to 255 in Java 11, see https://bugs.openjdk.org/browse/JDK-8244706
         };
         out.write(header, 0, header.length);
     }

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/GzipOutputStream.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/GzipOutputStream.java
@@ -33,7 +33,7 @@ public class GzipOutputStream extends DeflaterOutputStream {
                 0, // MTIME3
                 0, // MTIME4
                 0, // XFL
-                (byte) 255 // OS, changed from 0 to 255 in Java 11, see https://bugs.openjdk.org/browse/JDK-8244706
+                (byte) 255 // OS, changed from 0 to 255 in Java 16, see https://bugs.openjdk.org/browse/JDK-8244706
         };
         out.write(header, 0, header.length);
     }

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/util/GzipOutputStreamTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/util/GzipOutputStreamTest.java
@@ -12,8 +12,6 @@ import java.util.zip.GZIPOutputStream;
 
 import org.junit.Test;
 
-import fi.nls.hakunapi.core.util.GzipOutputStream;
-
 public class GzipOutputStreamTest {
 
     @Test

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/util/GzipOutputStreamTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/util/GzipOutputStreamTest.java
@@ -16,20 +16,25 @@ public class GzipOutputStreamTest {
 
     @Test
     public void testAgainstJDK() throws IOException {
-        byte[] input = generateRandomData(1024 * 1024);
+        byte[] input = generateRandomData(64 * 1024);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        OutputStream out = new GZIPOutputStream(baos, 8192);
-        out.write(input);
-        out.close();
+        try (OutputStream out = new GZIPOutputStream(baos)) {
+            out.write(input);
+        }
         byte[] expected = baos.toByteArray();
 
-        baos = new ByteArrayOutputStream();
+        baos.reset();
         Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
-        out = new GzipOutputStream(baos, deflater, 8192);
-        out.write(input);
-        out.close();
+        try (OutputStream out = new GzipOutputStream(baos, deflater, 8192)) {
+            out.write(input);
+        }
         byte[] actual = baos.toByteArray();
+
+        // GZIP "OS" header flag
+        // Changed from 0 to 255 in Java 16, see https://bugs.openjdk.org/browse/JDK-8244706
+        // GzipOutputStream outputs 255, JDK 11 outputs 0 -- ignore checking the OS header flag
+        actual[9] = expected[9];
 
         assertArrayEquals(expected, actual);
     }

--- a/src/hakunapi-cql2/pom.xml
+++ b/src/hakunapi-cql2/pom.xml
@@ -12,9 +12,6 @@
     <properties>
         <antrl.version>4.9.2</antrl.version>
         <mojo.version>3.0.0</mojo.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/hakunapi-csv/pom.xml
+++ b/src/hakunapi-csv/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-csv</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-esbulk/pom.xml
+++ b/src/hakunapi-esbulk/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-esbulk</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-geojson/pom.xml
+++ b/src/hakunapi-geojson/pom.xml
@@ -8,12 +8,6 @@
     </parent>
     <artifactId>hakunapi-geojson</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-gml/pom.xml
+++ b/src/hakunapi-gml/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-gml</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-gpkg/pom.xml
+++ b/src/hakunapi-gpkg/pom.xml
@@ -10,11 +10,6 @@
 
     <properties>
         <sqlite-jdbc.version>3.32.3.2</sqlite-jdbc.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     </properties>
 
     <dependencies>

--- a/src/hakunapi-html/pom.xml
+++ b/src/hakunapi-html/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-html</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-mvt/pom.xml
+++ b/src/hakunapi-mvt/pom.xml
@@ -13,11 +13,6 @@
 		<!-- wdtinc-mvt.version>3.1.1+nls1</wdtinc-mvt.version -->
 		<wdtinc-mvt.version>3.1.0</wdtinc-mvt.version>
 		<jts2geojson.version>0.14.0</jts2geojson.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 	</properties>
 
 	<dependencies>

--- a/src/hakunapi-proj-gt/pom.xml
+++ b/src/hakunapi-proj-gt/pom.xml
@@ -10,11 +10,6 @@
 
     <properties>
         <geotools.version>27.2</geotools.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     </properties>
 
     <repositories>

--- a/src/hakunapi-proj-jhe/pom.xml
+++ b/src/hakunapi-proj-jhe/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-proj-jhe</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-simple-servlet/pom.xml
+++ b/src/hakunapi-simple-servlet/pom.xml
@@ -12,11 +12,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
 

--- a/src/hakunapi-simple-webapp-test/pom.xml
+++ b/src/hakunapi-simple-webapp-test/pom.xml
@@ -12,8 +12,8 @@
 	
 	<properties>
 	       <json-path.version>2.7.0</json-path.version>
-	
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/hakunapi-simple-webapp/pom.xml
+++ b/src/hakunapi-simple-webapp/pom.xml
@@ -10,11 +10,6 @@
     <packaging>war</packaging>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>
 

--- a/src/hakunapi-smile/pom.xml
+++ b/src/hakunapi-smile/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-smile</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-source-postgis/pom.xml
+++ b/src/hakunapi-source-postgis/pom.xml
@@ -8,14 +8,6 @@
     </parent>
     <artifactId>hakunapi-source-postgis</artifactId>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>fi.nls.hakunapi</groupId>

--- a/src/hakunapi-tiles/pom.xml
+++ b/src/hakunapi-tiles/pom.xml
@@ -10,11 +10,6 @@
 
     <properties>
         <wdtinc-mvt.version>3.1.1+nls1</wdtinc-mvt.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-        <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
     </properties>
 
     <dependencies>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -7,7 +7,6 @@
             <artifactId>hakunapi</artifactId>
             <version>0.1.10-SNAPSHOT</version>
         </parent>
-	<groupId>fi.nls.hakunapi</groupId>
 	<artifactId>src</artifactId>
 	<packaging>pom</packaging>
 	<modules>


### PR DESCRIPTION
Java 11 is the new target, functionality added in Java 9-11 can now be used in code (e.g. this PR includes usage of `String.isBlank(String)` as an example).
 