### PR TITLE
Fix missing query params from items link without f

### DIFF
--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataUtil.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataUtil.java
@@ -28,12 +28,18 @@ public class CollectionMetadataUtil {
         String description = ft.getDescription();
 
         List<Link> links = new ArrayList<>();
+        // /collections/{collectionId}/items
         for (OutputFormat f : service.getOutputFormats()) {
-            links.add(getItemsLink(service, ft, f.getMimeType()));
+            links.add(getItemsLink(service, queryParams, ft, f));
         }
+
+        // /collections/{collectionId}/items?f={format}
         for (OutputFormat f : service.getOutputFormats()) {
-            links.add(getItemsLinkWithF(service, ft, queryParams, f));
+            queryParams.put("f", f.getId());
+            links.add(getItemsLink(service, queryParams, ft, f));
+            queryParams.remove("f");
         }
+
         links.add(getDescribedByLink(service, queryParams, ft));
         links.add(getQueryablesLinks(service, queryParams, ft));
 
@@ -59,6 +65,7 @@ public class CollectionMetadataUtil {
         return ci;
     }
 
+    @Deprecated
     public static Link getItemsLink(FeatureServiceConfig service, FeatureType ft, String mimeType) {
         String path = "/collections/" + ft.getName() + "/items";
         String href = service.getCurrentServerURL() + path;
@@ -67,6 +74,7 @@ public class CollectionMetadataUtil {
         return new Link(href, rel, type);
     }
 
+    @Deprecated
     public static Link getItemsLinkWithF(FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams, OutputFormat format) {
         queryParams.put("f", format.getId());
         String query = U.toQuery(queryParams);
@@ -75,6 +83,15 @@ public class CollectionMetadataUtil {
         String rel = ITEMS_REL;
         String type = format.getMimeType();
         queryParams.remove("f");
+        return new Link(href, rel, type);
+    }
+
+    private static Link getItemsLink(FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft, OutputFormat format) {
+        String query = U.toQuery(queryParams);
+        String path = "/collections/" + ft.getName() + "/items" + query;
+        String href = service.getCurrentServerURL() + path;
+        String rel = ITEMS_REL;
+        String type = format.getMimeType();
         return new Link(href, rel, type);
     }
     

--- a/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
+++ b/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
@@ -6,6 +6,7 @@ import static com.jayway.jsonassert.JsonAssert.with;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.either;
 
 import java.io.File;
 
@@ -14,6 +15,7 @@ import javax.ws.rs.core.Application;
 
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.TestProperties;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,6 +110,32 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 						hasItems("https://localhost/hakuna/collections/aallonmurtaja/items",
 								"https://localhost/hakuna/collections/aallonmurtaja/items?f=json"));
 	}
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCollectionsAallonmurtajaWithApiKey() {
+        final String response = target("/collections/aallonmurtaja").queryParam("api-key", "12345").request().get(String.class);
+        LOG.info(response);
+
+        with(response)
+                //
+                .assertThat("$.id", equalTo("aallonmurtaja"))
+                //
+                .assertThat("$.title", equalTo("Aallonmurtaja"))
+
+                //
+                .assertThat("$.links[?(@.rel == 'items')]", is(collectionWithSize(equalTo(2))))
+
+                //
+                .assertThat("$.links[?(@.rel == 'items')].href",
+                        either(
+                                hasItems("https://localhost/hakuna/collections/aallonmurtaja/items?api-key=12345",
+                                        "https://localhost/hakuna/collections/aallonmurtaja/items?api-key=12345&f=json")
+                        ).or(
+                                hasItems("https://localhost/hakuna/collections/aallonmurtaja/items?api-key=12345",
+                                        "https://localhost/hakuna/collections/aallonmurtaja/items?f=json&api-key=12345")
+                        ));
+    }
 
 	@Test
 	public void testCollectionsAallonmurtajaQueryables() {


### PR DESCRIPTION
Fixes #28 

For some reason

* `CollectionMetadataUtil.getItemsLink(FeatureServiceConfig service, FeatureType ft, String mimeType)`
* `CollectionMetadataUtil.getItemsLinkWithF(FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams, OutputFormat format)`

were both marked as public, so marked them as deprecated instead of removing/altering them.