### PR TITLE
Add f=json in metadata resources, add missing links

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
@@ -27,6 +27,7 @@ public abstract class FeatureServiceConfig {
     protected List<SecurityRequirement> securityRequirements;
     protected Map<String, Map<String, Object>> schemaExtensions;
     protected FunctionsContent functionsContent;
+    protected List<MetadataFormat> metadataFormats;
 
     public int getLimitDefault() {
         return limitDefault;
@@ -140,6 +141,17 @@ public abstract class FeatureServiceConfig {
 
     public void setFunctions(FunctionsContent functionsContent) {
         this.functionsContent = functionsContent;
+    }
+
+    public List<MetadataFormat> getMetadataFormats() {
+        if (metadataFormats == null) {
+            return List.of(MetadataFormat.JSON);
+        }
+        return metadataFormats;
+    }
+
+    public void setMetadataFormats(List<MetadataFormat> metadataFormats) {
+        this.metadataFormats = metadataFormats;
     }
 
     public String getTitle() {

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/MetadataFormat.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/MetadataFormat.java
@@ -1,0 +1,18 @@
+package fi.nls.hakunapi.core;
+
+import java.util.List;
+
+public enum MetadataFormat {
+
+    JSON("json", List.of("application/json", "application/schema+json", "application/vnd.oai.openapi+json;version=3.0")),
+    HTML("html", List.of("text/html"));
+
+    public final String id;
+    public final List<String> contentTypes;
+
+    private MetadataFormat(String id, List<String> contentTypes) {
+        this.id = id;
+        this.contentTypes = contentTypes;
+    }
+
+}

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/GlobalFQueryParamFilter.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/GlobalFQueryParamFilter.java
@@ -1,0 +1,54 @@
+package fi.nls.hakunapi.simple.servlet.javax;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+
+import fi.nls.hakunapi.core.MetadataFormat;
+
+@Provider
+@PreMatching
+public class GlobalFQueryParamFilter implements ContainerRequestFilter {
+
+    private static final String F_QUERY_PARAM = "f";
+
+    @Override
+    public void filter(ContainerRequestContext req) throws IOException {
+        String f = req.getUriInfo().getQueryParameters().getFirst(F_QUERY_PARAM);
+        if (f == null || f.isBlank()) {
+            return;
+        }
+
+        MetadataFormat format = Arrays.stream(MetadataFormat.values())
+                .filter(it -> it.id.equals(f))
+                .findAny()
+                .orElse(null);
+
+        if (format == null) {
+            String expected = Arrays.stream(MetadataFormat.values())
+                    .map(it -> it.id)
+                    .collect(Collectors.joining(",", "[", "]"));
+            req.abortWith(ResponseUtil.exception(
+                    Status.BAD_REQUEST,
+                    "Invalid value for param '" + F_QUERY_PARAM + "', expected one of " + expected));
+            return;
+        }
+
+        String accept = req.getHeaders().getFirst("accept");
+        String modified = modifyAcceptHeader(accept, format.contentTypes);
+        req.getHeaders().put("accept", List.of(modified));
+    }
+
+    private String modifyAcceptHeader(String accept, List<String> mediaTypeToPrefer) {
+        String a = mediaTypeToPrefer.stream().collect(Collectors.joining(","));
+        return accept == null || accept.isBlank() ? a : a + "," + accept;
+    }
+
+}

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
@@ -1,7 +1,6 @@
 package fi.nls.hakunapi.simple.servlet.javax.operation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -14,11 +13,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
 import fi.nls.hakunapi.core.FeatureType;
+import fi.nls.hakunapi.core.MetadataFormat;
 import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.schemas.CollectionInfo;
 import fi.nls.hakunapi.core.schemas.CollectionsContent;
 import fi.nls.hakunapi.core.schemas.Link;
-import fi.nls.hakunapi.core.util.U;
+import fi.nls.hakunapi.core.util.Links;
 import fi.nls.hakunapi.html.model.HTMLContext;
 
 @Path("/collections")
@@ -32,19 +32,20 @@ public class CollectionsMetadataImpl {
     public CollectionsContent handleJSON(@Context UriInfo uriInfo) {
         return handle(uriInfo, MediaType.APPLICATION_JSON);
     }
-    
+
     @GET
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<CollectionsContent> handleHTML(@Context UriInfo uriInfo) {
         return new HTMLContext<>(service, handle(uriInfo, MediaType.TEXT_HTML));
     }
-    
+
     private CollectionsContent handle(UriInfo uriInfo, String contentType) {
         Map<String, String> queryParams = OperationUtil.getQueryParams(service, uriInfo);
-        String query = U.toQuery(queryParams);
-        
-        Link self = getSelfLink(query, contentType);
-        List<Link> links = Collections.singletonList(self);
+
+        String path = service.getCurrentServerURL() + "/collections";
+        List<Link> links = new ArrayList<>();
+        links.add(Links.getSelfLink(path, queryParams, contentType));
+        links.addAll(getAlternateLinks(path, queryParams, contentType));
 
         List<CollectionInfo> collections = new ArrayList<>();
         for (FeatureType ft : service.getCollections()) {
@@ -55,11 +56,22 @@ public class CollectionsMetadataImpl {
         return new CollectionsContent(links, collections);
     }
 
-    private Link getSelfLink(String query, String contentType) {
-        String href = service.getCurrentServerURL() + "/collections" + query;
-        String rel = "self";
-        String type = contentType;
-        return new Link(href, rel, type, "This document");
+    private List<Link> getAlternateLinks(String path, Map<String, String> queryParams, String contentType) {
+        return service.getMetadataFormats().stream()
+                .filter(it -> !it.contentTypes.contains(contentType))
+                .map(it -> toAlternateLink(path, queryParams, it))
+                .toList();
+    }
+
+    private Link toAlternateLink(String path, Map<String, String> queryParams, MetadataFormat format) {
+        String mimeTypeHuman = format.id;
+        String mimeType;
+        if (format == MetadataFormat.JSON) {
+            mimeType = MediaType.APPLICATION_JSON;
+        } else { // if (format == MetadataFormat.JSON) {
+            mimeType = MediaType.TEXT_HTML;
+        }
+        return Links.getAlternateLink(path, queryParams, mimeType, mimeTypeHuman);
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
@@ -3,6 +3,7 @@ package fi.nls.hakunapi.simple.servlet.javax.operation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -60,7 +61,7 @@ public class CollectionsMetadataImpl {
         return service.getMetadataFormats().stream()
                 .filter(it -> !it.contentTypes.contains(contentType))
                 .map(it -> toAlternateLink(path, queryParams, it))
-                .toList();
+                .collect(Collectors.toList());
     }
 
     private Link toAlternateLink(String path, Map<String, String> queryParams, MetadataFormat format) {

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
@@ -253,15 +253,16 @@ public class GetCollectionItemsOperation implements DynamicPathOperation, Dynami
         Link self = Links.getSelfLink(path, queryParams, mimeType);
         links.add(self);
 
-        String fParamValue = queryParams.get(FParam.QUERY_PARAM_NAME);
+        String fParamOriginalValue = queryParams.get(FParam.QUERY_PARAM_NAME);
         for (OutputFormat f : service.getOutputFormats()) {
             if (!f.getId().equals(request.getFormat().getId())) {
+                queryParams.remove(FParam.QUERY_PARAM_NAME);
+                links.add(Links.getAlternateLink(path, queryParams, f.getMimeType(), f.getId()));
                 queryParams.put(FParam.QUERY_PARAM_NAME, f.getId());
-                Link alt = Links.getAlternateLink(path, queryParams, f.getMimeType(), f.getId());
-                links.add(alt);
+                links.add(Links.getAlternateLink(path, queryParams, f.getMimeType(), f.getId()));
             }
         }
-        queryParams.put(FParam.QUERY_PARAM_NAME, fParamValue);
+        queryParams.put(FParam.QUERY_PARAM_NAME, fParamOriginalValue);
 
         if (report.next != null) {
             queryParams.put(NextParam.PARAM_NAME, report.next.toWireFormat());

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import fi.nls.hakunapi.core.ConformanceClass;
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.FilterParser;
+import fi.nls.hakunapi.core.MetadataFormat;
 import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.OutputFormatProvider;
 import fi.nls.hakunapi.core.SimpleSource;
@@ -130,6 +131,7 @@ public class HakunaContextListener implements ServletContextListener {
             service.setSecuritySchemes(securitySchemes);
             service.setSecurityRequirements(securityRequirements);
             service.setFunctions(functionsMetadata);
+            service.setMetadataFormats(List.of(MetadataFormat.JSON, MetadataFormat.HTML));
 
             LOG.info("Starting OGC API Features service with collections: {}", collections);
             sce.getServletContext().setAttribute("hakunaService", service);

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
@@ -35,6 +35,7 @@ import fi.nls.hakunapi.html.OutputFormatHTML;
 import fi.nls.hakunapi.simple.servlet.javax.CacheManager;
 import fi.nls.hakunapi.simple.servlet.javax.CatchAllExceptionMapper;
 import fi.nls.hakunapi.simple.servlet.javax.CorsFilter;
+import fi.nls.hakunapi.simple.servlet.javax.GlobalFQueryParamFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GzipFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GzipInterceptor;
 import fi.nls.hakunapi.simple.servlet.javax.NotFoundExceptionMapper;
@@ -87,6 +88,8 @@ public class SimpleFeaturesApplication extends ResourceConfig {
 
         register(NotFoundExceptionMapper.class);
         register(CatchAllExceptionMapper.class);
+
+        register(GlobalFQueryParamFilter.class);
 
         if (Boolean.parseBoolean(parser.get("hakuna.cors", "true"))) {
             register(CorsFilter.class);


### PR DESCRIPTION
Add `?f=json/html` throughout the API as discussed in #25.

With that done, fix ETS validation error:
* Missing alternate encoding links in `/collections`

In addition
* Missing alternate encoding links in `/collections/{collectionId}/items/{featureId}`
  * This was also spotted via ETS validation
* Add alternate encoding links without `?f={format}` parameter in `/collections/{collectionId}/items`
  * Not necessarily required but consistent with the forward links in `/collections` and `/collections/{collectionId}` which include both variants