### PR TITLE
Add validation to spatial extent

### DIFF
--- a/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
+++ b/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
@@ -86,8 +86,9 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 
 		with(response)
 				//
-				.assertThat("$.collections[?(@.id == 'aallonmurtaja')]", is(collectionWithSize(equalTo(1))));
-
+				.assertThat("$.collections[?(@.id == 'aallonmurtaja')]", is(collectionWithSize(equalTo(1))))
+				.assertThat("$.collections[?(@.id == 'test_collection')]", is(collectionWithSize(equalTo(1))))
+				.assertThat("$.collections[?(@.id == 'should_not_exist')]", is(collectionWithSize(equalTo(0))));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -225,4 +226,33 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 				.assertThat("$.geometry", mapContainingKey(equalTo("type")));
 
 	}
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testTestCollection() {
+        final String response = target("/collections/test_collection").request().get(String.class);
+        LOG.info(response);
+
+        with(response)
+                //
+                .assertThat("$.id", equalTo("test_collection"))
+                //
+                .assertThat("$.title", equalTo("Test Collection"))
+
+                .assertThat("$.extent.spatial.bbox", collectionWithSize(equalTo(1)))
+                .assertThat("$.extent.spatial.bbox[0]", collectionWithSize(equalTo(4)))
+                .assertThat("$.extent.spatial.bbox[0][0]", equalTo(-110.0))
+                .assertThat("$.extent.spatial.bbox[0][1]", equalTo(-60.0))
+                .assertThat("$.extent.spatial.bbox[0][2]", equalTo(140.0))
+                .assertThat("$.extent.spatial.bbox[0][3]", equalTo(30.0))
+
+                //
+                .assertThat("$.links[?(@.rel == 'items')]", is(collectionWithSize(equalTo(2))))
+
+                //
+                .assertThat("$.links[?(@.rel == 'items')].href",
+                        hasItems("https://localhost/hakuna/collections/test_collection/items",
+                                "https://localhost/hakuna/collections/test_collection/items?f=json"));
+    }
+
 }

--- a/src/hakunapi-simple-webapp-test-javax/src/test/resources/hakuna/hakuna.properties
+++ b/src/hakunapi-simple-webapp-test-javax/src/test/resources/hakuna/hakuna.properties
@@ -25,7 +25,7 @@ getfeatures.limit.max=10000
 db.classes=fi.nls.hakunapi.source.HakunaTestSource
 db=db
 
-collections=aallonmurtaja
+collections=aallonmurtaja,test_collection
 collections.aallonmurtaja.type=test
 collections.aallonmurtaja.db=db
 collections.aallonmurtaja.table=aallonmurtaja
@@ -53,4 +53,19 @@ collections.aallonmurtaja.time=alkupvm
 
 collections.aallonmurtaja.testdata.1=1;POINT(1 1 100);11;4.0;1;null;null;11;12;13
 collections.aallonmurtaja.testdata.2=2;POINT(1 1 100);22;4.0;1;null;null;21;22;23
+
+collections.test_collection.type=test
+collections.test_collection.db=db
+collections.test_collection.table=test_table
+collections.test_collection.extent.spatial.crs84=-110,-60,140,30
+collections.test_collection.title=Test Collection
+collections.test_collection.description=Collection for testing purposes
+collections.test_collection.srid=3067,4258,3046,3047,3048,3873,3874,3875,3876,3877,3878,3879,3880,3881,3882,3883,3884,3885
+collections.test_collection.writeNulls=true
+collections.test_collection.id.mapping=fid
+collections.test_collection.geometry.mapping=geom
+collections.test_collection.geometry.type=POINT
+collections.test_collection.properties=my_prop
+collections.test_collection.testdata.1=1;POINT(1 1 100);11
+collections.test_collection.testdata.2=2;POINT(1 1 100);22
 


### PR DESCRIPTION
Add warning for collections that don't have a spatial extent configured (but do have a geometry property)
In addition, validate that the configured spatial extent is within CRS84 bounds `Envelope (-180, -90, 180, 90)`

See #35