### PR TITLE
Add links to JSON representation + Github

### DIFF
--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
@@ -9,12 +9,22 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections">Collections</a></li>
         <li class="breadcrumb-item active" aria-current="page">${model.title!model.id}</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -45,6 +55,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
@@ -9,11 +9,21 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
         <li class="breadcrumb-item active" aria-current="page">Collections</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -30,6 +40,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
@@ -9,11 +9,21 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
         <li class="breadcrumb-item active" aria-current="page">Conformance</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -30,6 +40,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
@@ -16,7 +16,7 @@
 <body>
 <main>
   <div class="container py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../collections">Collections</a></li>
@@ -24,6 +24,16 @@
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../collections/${featureType.name}/items">Items</a></li>
         <li class="breadcrumb-item active" aria-current="page">${id}</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -52,6 +62,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -14,13 +14,23 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../collections">Collections</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../collections/${featureType.name}">${(featureType.title)!(featureType.name)}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Items</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -99,6 +109,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
@@ -16,13 +16,23 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../collections">Collections</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../collections/${featureType.name}">${(featureType.title)!(featureType.name)}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Items</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -101,6 +111,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
@@ -18,7 +18,7 @@
 <body>
 <main>
   <div class="container py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../collections">Collections</a></li>
@@ -26,6 +26,16 @@
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="../../../collections/${featureType.name}/items?crs=http%3A%2F%2Fwww.opengis.net%2Fdef%2Fcrs%2FEPSG%2F0%2F3067">Items</a></li>
         <li class="breadcrumb-item active" aria-current="page">${id}</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -54,6 +64,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
@@ -9,13 +9,23 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections">Collections</a></li>
         <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections/${model.collectionId}">${(model.title)!(model.collectionId)}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Queryables</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -33,6 +43,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
@@ -9,10 +9,20 @@
 <body>
 <main>
   <div class="container-lg py-4">
-    <nav aria-label="breadcrumb">
+    <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item active" aria-current="page">Home</li>
       </ol>
+      <ul class="nav">
+        <li class="nav-item">
+          <a class="navbar-brand" id="json-link" target="_blank">JSON</a>
+        </li>
+        <li class="nav-item">
+          <a href="https://github.com/nlsfi/hakunapi" target="_blank">
+            <svg width="32" height="32" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="#24292f"/></svg>
+          </a>
+        </li>
+      </ul>
     </nav>
 
     <header class="pb-2 mb-2">
@@ -39,6 +49,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>
 </main>
+<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Added two links to default HTML templates:
* Link to JSON format of the current page f=json as visioned in #29
* While at it a link to the projects Github page

Looks like this:
![image](https://github.com/nlsfi/hakunapi/assets/2799041/1daea3be-0dfe-447d-88a0-c0ed8519086d)
