### PR TITLE
GeoJSON axis order

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
@@ -28,6 +28,7 @@ public abstract class FeatureServiceConfig {
     protected Map<String, Map<String, Object>> schemaExtensions;
     protected FunctionsContent functionsContent;
     protected List<MetadataFormat> metadataFormats;
+    protected List<SRIDCode> knownSrids;
 
     public int getLimitDefault() {
         return limitDefault;
@@ -152,6 +153,26 @@ public abstract class FeatureServiceConfig {
 
     public void setMetadataFormats(List<MetadataFormat> metadataFormats) {
         this.metadataFormats = metadataFormats;
+    }
+
+    public void setKnownSrids(List<SRIDCode> knownSrids) {
+        this.knownSrids = knownSrids;
+    }
+
+    public boolean isCrsLatLon(int srid) {
+        if (srid == 4326) {
+            // 4326 is well known at hakunapi level
+            return true;
+        }
+        if (knownSrids == null || knownSrids.isEmpty()) {
+            // Known srids aren't configured
+            return false;
+        }
+        return knownSrids.stream()
+                .filter(it -> it.getSrid() == srid)
+                .findAny()
+                .map(it -> it.isLatLon())
+                .orElse(false);
     }
 
     public String getTitle() {

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureWriter.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureWriter.java
@@ -15,11 +15,37 @@ public interface FeatureWriter extends AutoCloseable {
 
     public String getMimeType();
     public int getSrid();
+
+    @Deprecated
+    /**
+     * @deprecated use init(OutputStream, int, int, boolean) instead
+     */
     public default void init(OutputStream out, int maxDecimalsCoordinate, int srid) throws Exception {
-        init(out, new DefaultFloatingPointFormatter(0, 5, 0, 8, 0, maxDecimalsCoordinate),srid);
+        init(out, maxDecimalsCoordinate, srid, false);
+    }
+
+    public default void init(OutputStream out, int maxDecimalsCoordinate, int srid, boolean crsIsLatLon) throws Exception {
+        int minDecimalsFloat = 0;
+        int maxDecimalsFloat = 5;
+        int maxDecimalsDouble = 0;
+        int minDecimalsDouble = 8;
+        int minDecimalsOrdinate = 0;
+        FloatingPointFormatter f = new DefaultFloatingPointFormatter(
+                minDecimalsFloat,
+                maxDecimalsFloat,
+                minDecimalsDouble,
+                maxDecimalsDouble,
+                minDecimalsOrdinate,
+                maxDecimalsCoordinate);
+        init(out, f, srid, crsIsLatLon);
     };
+
+    public default void init(OutputStream out, FloatingPointFormatter formatter, int srid, boolean crsIsLatLon) throws Exception {
+        init(out, formatter, srid);
+    }
+
     public void init(OutputStream out, FloatingPointFormatter formatter, int srid) throws Exception;
-   
+
     public default void initGeometryWriter(HakunaGeometryDimension dims) {};
     
     public void end(boolean timeStamp, List<Link> links, int numberReturned) throws Exception;

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/SRIDCode.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/SRIDCode.java
@@ -1,0 +1,21 @@
+package fi.nls.hakunapi.core;
+
+public class SRIDCode {
+
+    private final int srid;
+    private final boolean latLon;
+
+    public SRIDCode(int srid, boolean latLon) {
+        this.srid = srid;
+        this.latLon = latLon;
+    }
+
+    public int getSrid() {
+        return srid;
+    }
+
+    public boolean isLatLon() {
+        return latLon;
+    }
+
+}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.nls.hakunapi.core.CacheSettings;
 import fi.nls.hakunapi.core.DatetimeProperty;
 import fi.nls.hakunapi.core.FeatureType;
+import fi.nls.hakunapi.core.SRIDCode;
 import fi.nls.hakunapi.core.SimpleFeatureType;
 import fi.nls.hakunapi.core.SimpleSource;
 import fi.nls.hakunapi.core.filter.Filter;
@@ -146,6 +147,17 @@ public class HakunaConfigParser {
             securitySchemes.put(name, ss);
         }
         return Optional.of(securitySchemes);
+    }
+
+    public List<SRIDCode> getKnownSrids() {
+        List<SRIDCode> knownSrids = new ArrayList<>();
+        for (String sridCode : getMultiple("srid")) {
+            int srid = Integer.parseInt(sridCode);
+            String latLonAttr = get("srid." + sridCode + ".latLon", "false");
+            boolean latLon = "true".equalsIgnoreCase(latLonAttr);
+            knownSrids.add(new SRIDCode(srid, latLon));
+        }
+        return knownSrids;
     }
 
     public List<HakunaProperty> parseTimeProperties(List<HakunaProperty> properties, String[] timePropertyNames)

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -81,9 +81,9 @@ public class HakunaConfigParser {
     
     public Info readInfo() {
         Info info = new Info();
-        info.setTitle(cfg.getProperty("api.title", "Hakuna OGC API Features Server"));
+        info.setTitle(cfg.getProperty("api.title", "hakunapi OGC API Features Server"));
         info.setVersion(cfg.getProperty("api.version", "0.0.1"));
-        info.setDescription(cfg.getProperty("api.description", "Hakuna OGC API Features Server 0.0.7"));
+        info.setDescription(cfg.getProperty("api.description", "hakunapi OGC API Features Server"));
 
         Contact contact = new Contact();
         contact.setName(cfg.getProperty("api.contact.name", "N/A"));

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONFeatureCollectionWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONFeatureCollectionWriter.java
@@ -12,8 +12,8 @@ import fi.nls.hakunapi.core.schemas.Link;
 public class HakunaGeoJSONFeatureCollectionWriter extends HakunaGeoJSONWriter implements FeatureCollectionWriter {
 
     @Override
-    public void init(OutputStream out, FloatingPointFormatter formatter,int srid) throws IOException {
-        super.init(out, formatter, srid);
+    public void init(OutputStream out, FloatingPointFormatter formatter, int srid, boolean crsIsLatLon) throws IOException {
+        super.init(out, formatter, srid, crsIsLatLon);
         writeFeatureCollection();
     }
     

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
@@ -9,15 +9,19 @@ public class HakunaGeoJSONGeometryWriter implements GeometryWriter {
 
     protected final HakunaJsonWriter json;
     protected final byte[] fieldName;
+    protected final boolean lonLat;
 
-    public HakunaGeoJSONGeometryWriter(HakunaJsonWriter json, byte[] fieldName) {
+    public HakunaGeoJSONGeometryWriter(HakunaJsonWriter json, byte[] fieldName, boolean lonLat) {
         this.json = json;
         this.fieldName = fieldName;
+        this.lonLat = lonLat;
     }
 
     @Override
     public void init(HakunaGeometryType type, int srid, int dimension) throws IOException {
-        json.writeFieldName(fieldName);
+        if (fieldName != null) {
+            json.writeFieldName(fieldName);
+        }
         json.writeStartObject();
         json.writeFieldName(HakunaGeoJSON.TYPE);
         json.writeStringUnsafe(getTypeUTF8(type));
@@ -41,15 +45,27 @@ public class HakunaGeoJSONGeometryWriter implements GeometryWriter {
     }
 
     public void writeCoordinate(double x, double y) throws IOException {
-        json.writeCoordinate(x, y);
+        if (lonLat) {
+            json.writeCoordinate(x, y);
+        } else {
+            json.writeCoordinate(y, x);
+        }
     }
 
     public void writeCoordinate(double x, double y, double z) throws IOException {
-        json.writeCoordinate(x, y, z);
+        if (lonLat) {
+            json.writeCoordinate(x, y, z);
+        } else {
+            json.writeCoordinate(y, x, z);
+        }
     }
 
     public void writeCoordinate(double x, double y, double z, double m) throws IOException {
-        json.writeCoordinate(x, y, z, m);
+        if (lonLat) {
+            json.writeCoordinate(x, y, z, m);
+        } else {
+            json.writeCoordinate(y, x, z, m);
+        }
     }
 
     public void startRing() throws IOException {

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
@@ -15,6 +15,7 @@ public class HakunaGeoJSONGeometryWriter implements GeometryWriter {
         this.fieldName = fieldName;
     }
 
+    @Override
     public void init(HakunaGeometryType type, int srid, int dimension) throws IOException {
         json.writeFieldName(fieldName);
         json.writeStartObject();

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
@@ -20,6 +20,7 @@ public class HakunaGeoJSONGeometryXYZMWriter implements GeometryWriter {
         this.mode = mode;
     }
 
+    @Override
     public void init(HakunaGeometryType type, int srid, int dimension) throws IOException {
         json.writeFieldName(fieldName);
         json.writeStartObject();

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
@@ -2,94 +2,45 @@ package fi.nls.hakunapi.geojson.hakuna;
 
 import java.io.IOException;
 
-import fi.nls.hakunapi.core.GeometryWriter;
-import fi.nls.hakunapi.core.geom.HakunaGeometryType;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 
-
-public class HakunaGeoJSONGeometryXYZMWriter implements GeometryWriter {
+public class HakunaGeoJSONGeometryXYZMWriter extends HakunaGeoJSONGeometryWriter {
 
     private final HakunaGeometryDimension mode;
-    private final HakunaJsonWriter json;
-    private final byte[] fieldName;
 
     public HakunaGeoJSONGeometryXYZMWriter(HakunaJsonWriter json, byte[] fieldName,
+            boolean lonLat,
             HakunaGeometryDimension mode) {
-        this.json = json;
-        this.fieldName = fieldName;
+        super(json, fieldName, lonLat);
         this.mode = mode;
     }
 
     @Override
-    public void init(HakunaGeometryType type, int srid, int dimension) throws IOException {
-        json.writeFieldName(fieldName);
-        json.writeStartObject();
-        json.writeFieldName(HakunaGeoJSON.TYPE);
-        json.writeStringUnsafe(getTypeUTF8(type));
-        json.writeFieldName(HakunaGeoJSON.COORDINATES);
-    }
-
-    public void end() throws IOException {
-        json.writeEndObject();
-    }
-
-    private byte[] getTypeUTF8(HakunaGeometryType type) {
-        switch (type) {
-        case POINT: return HakunaGeoJSON.POINT;
-        case LINESTRING: return HakunaGeoJSON.LINESTRING;
-        case POLYGON: return HakunaGeoJSON.POLYGON;
-        case MULTIPOINT: return HakunaGeoJSON.MULTI_POINT;
-        case MULTILINESTRING: return HakunaGeoJSON.MULTI_LINESTRING;
-        case MULTIPOLYGON: return HakunaGeoJSON.MULTI_POLYGON;
-        default: throw new IllegalArgumentException();
-        }
-    }
-
-    public void writeCoordinate(double x, double y) throws IOException {
-        json.writeCoordinate(x, y);
-    }
-
     public void writeCoordinate(double x, double y, double z) throws IOException {
         switch(mode) {
         case XY:
-            json.writeCoordinate(x, y);
+            super.writeCoordinate(x, y);
             break;
-        case DEFAULT:
-        case GEOMETRY:
-        case XYZ:
-        case XYZM:
         default:
-            json.writeCoordinate(x, y, z);
+            super.writeCoordinate(x, y, z);
             break;
         
         }
     }
 
+    @Override
     public void writeCoordinate(double x, double y, double z, double m) throws IOException {
         switch(mode) {
         case XY:
-            json.writeCoordinate(x, y);
+            super.writeCoordinate(x, y);
             break;
         case XYZ:
-            json.writeCoordinate(x, y, z);
+            super.writeCoordinate(x, y, z);
             break;
-        case DEFAULT:
-        case GEOMETRY:
-        case XYZM:
         default:
-            json.writeCoordinate(x, y, z, m);
+            super.writeCoordinate(x, y, z, m);
             break;
         }
     }
 
-
-    public void startRing() throws IOException {
-        json.writeStartArray();
-    }
-
-    public void endRing() throws IOException {
-        json.writeEndArray();
-    }
-
 }
-

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/OutputFormatFactoryGeoJSON.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/OutputFormatFactoryGeoJSON.java
@@ -14,7 +14,10 @@ public class OutputFormatFactoryGeoJSON implements OutputFormatFactorySpi {
 
     @Override
     public OutputFormat create(Map<String, String> params) {
-        return OutputFormatGeoJSON.INSTANCE;
+        boolean forceLonLat = "true".equalsIgnoreCase(params.get("forceLonLat"));
+        return forceLonLat
+                ? OutputFormatGeoJSON.INSTANCE_LON_LAT
+                : OutputFormatGeoJSON.INSTANCE;
     }
 
 }

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/OutputFormatGeoJSON.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/OutputFormatGeoJSON.java
@@ -6,10 +6,15 @@ import fi.nls.hakunapi.core.SingleFeatureWriter;
 
 public class OutputFormatGeoJSON implements OutputFormat {
 
-    public static final OutputFormat INSTANCE = new OutputFormatGeoJSON();
+    public static final OutputFormat INSTANCE = new OutputFormatGeoJSON(false);
+    public static final OutputFormat INSTANCE_LON_LAT = new OutputFormatGeoJSON(true);
     public static final String TYPE = "json";
 
-    private OutputFormatGeoJSON() {}
+    private final boolean forceLonLat;
+
+    OutputFormatGeoJSON(boolean forceLonLat) {
+        this.forceLonLat = forceLonLat;
+    }
 
     @Override
     public String getId() {
@@ -23,12 +28,16 @@ public class OutputFormatGeoJSON implements OutputFormat {
 
     @Override
     public FeatureCollectionWriter getFeatureCollectionWriter() {
-        return new HakunaGeoJSONFeatureCollectionWriter();
+        HakunaGeoJSONFeatureCollectionWriter w = new HakunaGeoJSONFeatureCollectionWriter();
+        w.setForceLonLat(forceLonLat);
+        return w;
     }
 
     @Override
     public SingleFeatureWriter getSingleFeatureWriter() {
-        return new HakunaGeoJSONSingleFeatureWriter();
+        HakunaGeoJSONSingleFeatureWriter w = new HakunaGeoJSONSingleFeatureWriter();
+        w.setForceLonLat(forceLonLat);
+        return w;
     }
 
     @Override

--- a/src/hakunapi-geojson/src/test/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONWriterTest.java
+++ b/src/hakunapi-geojson/src/test/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONWriterTest.java
@@ -33,16 +33,37 @@ public class HakunaGeoJSONWriterTest {
         try (SingleFeatureWriter fw = new HakunaGeoJSONSingleFeatureWriter()) {
             fw.init(baos, new DefaultFloatingPointFormatter(0, 5, 0, 8, 0, 5),84);
             fw.startFeature(null, null, 1L);
-            fw.writeGeometry("ignored", getPointGeom(100.0, 200.0));
+            fw.writeGeometry("ignored", getPointGeom(130, 50));
             fw.writeProperty("foo", "bar");
             fw.writeProperty("prop0", 0);
             fw.writeProperty("nimi", "\"SOLSIDA\"");
             fw.writeNullProperty("prop1");
-            fw.writeProperty("another_geom", getPointGeom(100.0, 200.0));
+            fw.writeProperty("another_geom", getPointGeom(130, 50));
             fw.endFeature();
             fw.end(false, Collections.emptyList(), 1);
         }
         byte[] expecteds = loadResource("expect.json");
+        byte[] actuals = baos.toByteArray();
+        assertArrayEquals(expecteds, actuals);
+    }
+
+    @Test
+    public void testWriteFeatureLatLon() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (SingleFeatureWriter fw = new HakunaGeoJSONSingleFeatureWriter()) {
+            boolean crsIsLatLon = true;
+            fw.init(baos, new DefaultFloatingPointFormatter(0, 5, 0, 8, 0, 5), 4326, crsIsLatLon);
+            fw.startFeature(null, null, 1L);
+            fw.writeGeometry("ignored", getPointGeom(130, 50));
+            fw.writeProperty("foo", "bar");
+            fw.writeProperty("prop0", 0);
+            fw.writeProperty("nimi", "\"SOLSIDA\"");
+            fw.writeNullProperty("prop1");
+            fw.writeProperty("another_geom", getPointGeom(130, 50));
+            fw.endFeature();
+            fw.end(false, Collections.emptyList(), 1);
+        }
+        byte[] expecteds = loadResource("expect_latlon.json");
         byte[] actuals = baos.toByteArray();
         assertArrayEquals(expecteds, actuals);
     }

--- a/src/hakunapi-geojson/src/test/resources/expect.json
+++ b/src/hakunapi-geojson/src/test/resources/expect.json
@@ -1,1 +1,1 @@
-{"type":"Feature","id":1,"geometry":{"type":"Point","coordinates":[100,200]},"properties":{"foo":"bar","prop0":0,"nimi":"\"SOLSIDA\"","prop1":null,"another_geom":{"type":"Point","coordinates":[100,200]}}}
+{"type":"Feature","id":1,"geometry":{"type":"Point","coordinates":[130,50]},"properties":{"foo":"bar","prop0":0,"nimi":"\"SOLSIDA\"","prop1":null,"another_geom":{"type":"Point","coordinates":[130,50]}}}

--- a/src/hakunapi-geojson/src/test/resources/expect_latlon.json
+++ b/src/hakunapi-geojson/src/test/resources/expect_latlon.json
@@ -1,0 +1,1 @@
+{"type":"Feature","id":1,"geometry":{"type":"Point","coordinates":[50,130]},"properties":{"foo":"bar","prop0":0,"nimi":"\"SOLSIDA\"","prop1":null,"another_geom":{"type":"Point","coordinates":[50,130]}}}

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HakunaGeoJSONGeometryWriterNoField.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HakunaGeoJSONGeometryWriterNoField.java
@@ -2,36 +2,13 @@ package fi.nls.hakunapi.html.model;
 
 import java.io.IOException;
 
-import fi.nls.hakunapi.core.geom.HakunaGeometryType;
-import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSON;
 import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSONGeometryWriter;
 import fi.nls.hakunapi.geojson.hakuna.HakunaJsonWriter;
 
 public class HakunaGeoJSONGeometryWriterNoField extends HakunaGeoJSONGeometryWriter {
 
     public HakunaGeoJSONGeometryWriterNoField(HakunaJsonWriter json) {
-        super(json, null);
-    }
-
-    @Override
-    public void init(HakunaGeometryType type, int srid, int dimension) throws IOException {
-        // json.writeFieldName(fieldName);
-        json.writeStartObject();
-        json.writeFieldName(HakunaGeoJSON.TYPE);
-        json.writeString(getTypeName(type));
-        json.writeFieldName(HakunaGeoJSON.COORDINATES);
-    }
-
-    protected String getTypeName(HakunaGeometryType type) {
-        switch (type) {
-        case POINT: return "Point";
-        case LINESTRING: return "LineString";
-        case POLYGON: return "Polygon";
-        case MULTIPOINT: return "MultiPoint";
-        case MULTILINESTRING: return "MultiLineString";
-        case MULTIPOLYGON: return "MultiPolygon";
-        default: throw new IllegalArgumentException();
-        }
+        super(json, null, true);
     }
 
     @Override

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
@@ -144,10 +144,13 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
 
         int srid = request.getSRID();
 
+        int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+        boolean crsIsLatLon = service.isCrsLatLon(srid);
+
         // Feature response rarely needs 8kb of memory
         // Let's allocate a little less
         ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
-        writer.init(baos, CrsUtil.getMaxDecimalCoordinates(srid), srid);
+        writer.init(baos, maxDecimalCoordinates, srid, crsIsLatLon);
         if (c.getFt().getGeom() != null) {
             writer.initGeometryWriter(CrsUtil.getGeomDimensionForSrid(c.getFt().getGeomDimension(), srid));
         }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
@@ -208,10 +208,15 @@ public class GetCollectionItemsOperation implements DynamicPathOperation, Dynami
         GetFeatureCollection c = request.getCollections().get(0);
         FeatureType ft = c.getFt();
         FeatureProducer producer = c.getFt().getFeatureProducer();
+
+        int srid = request.getSRID();
+
+        int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+        boolean crsIsLatLon = service.isCrsLatLon(srid);
+
         try (FeatureStream features = producer.getFeatures(request, c);
                 FeatureCollectionWriter writer = request.getFormat().getFeatureCollectionWriter()) {
-            int srid = request.getSRID();
-            writer.init(out, CrsUtil.getMaxDecimalCoordinates(srid), srid);
+            writer.init(out, maxDecimalCoordinates, srid, crsIsLatLon);
             writer.initGeometryWriter(
                     CrsUtil.getGeomDimensionForSrid(c.getFt().getGeomDimension(), srid));
             writer.startFeatureCollection(ft, c.getName());

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -34,6 +34,7 @@ import fi.nls.hakunapi.core.FilterParser;
 import fi.nls.hakunapi.core.MetadataFormat;
 import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.OutputFormatProvider;
+import fi.nls.hakunapi.core.SRIDCode;
 import fi.nls.hakunapi.core.SimpleSource;
 import fi.nls.hakunapi.core.config.HakunaApplicationJson;
 import fi.nls.hakunapi.core.config.HakunaConfigParser;
@@ -42,7 +43,6 @@ import fi.nls.hakunapi.core.util.PropertyUtil;
 import fi.nls.hakunapi.cql2.function.CQL2Functions;
 import fi.nls.hakunapi.cql2.text.CQL2Text;
 import fi.nls.hakunapi.geojson.hakuna.OutputFormatGeoJSON;
-import fi.nls.hakunapi.simple.postgis.PostGISSimpleSource;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -92,6 +92,7 @@ public class HakunaContextListener implements ServletContextListener {
                 securityRequirements = securitySchemes.keySet().stream()
                         .map(name -> new SecurityRequirement().addList(name)).collect(Collectors.toList());
             }
+            List<SRIDCode> knownSrids = parser.getKnownSrids();
 
             Map<String, FeatureType> collections = new HashMap<>();
             for (String collectionId : parser.readCollectionIds()) {
@@ -132,6 +133,7 @@ public class HakunaContextListener implements ServletContextListener {
             service.setSecurityRequirements(securityRequirements);
             service.setFunctions(functionsMetadata);
             service.setMetadataFormats(List.of(MetadataFormat.JSON, MetadataFormat.HTML));
+            service.setKnownSrids(knownSrids);
 
             LOG.info("Starting OGC API Features service with collections: {}", collections);
             sce.getServletContext().setAttribute("hakunaService", service);


### PR DESCRIPTION
_See discussion in https://github.com/nlsfi/hakunapi/issues/51_

Change the GeoJSON outputformat to respect authority axis order by default.

Users can still override to force the GIS-friendly lon, lat order for GeoJSON via configuration:
```
formats=geojson
formats.geojson.type=json
formats.geojson.forceLonLat=true
```

By default hakunapi does not have access to the CRS EPSG definitions and thereby has no idea of the authority axis order.
This PR adds support for manually configuring them by adding them to the `knownSrids` list via configuration:
```
srid=3067,4258
srid.4258.latLon=true
```
The default value for any srid is `latLon=false` if no other configuration is found.
CRS:84 (lon, lat) and EPSG:4326 (lat, lon) do not need to be configured, they are well known by hakunapi by default.

Currently the configured `knownSrids` list is only used for determining the axis order of a crs. This means that if one would omit the `3067` from `srid=3067,4258` the result would be identical: hakunapi thinks that the axis order of 3067 is lon, lat (which happens to be correct).
