### PR TITLE
Perform axis order swap for bbox cordinates if bbox-crs is lat,lon

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/param/BboxCrsParam.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/param/BboxCrsParam.java
@@ -7,6 +7,7 @@ import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.core.property.simple.HakunaPropertyGeometry;
 import fi.nls.hakunapi.core.request.GetFeatureCollection;
 import fi.nls.hakunapi.core.request.GetFeatureRequest;
+import fi.nls.hakunapi.core.util.AxisOrderSwapFilter;
 import fi.nls.hakunapi.core.util.CrsUtil;
 import fi.nls.hakunapi.core.util.FilterUtil;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -53,6 +54,10 @@ public class BboxCrsParam implements GetFeatureParam {
             }
             Geometry bbox = (Geometry) bboxFilter.getValue();
             bbox.setSRID(srid);
+
+            if (service.isCrsLatLon(srid)) {
+                bbox.apply(new AxisOrderSwapFilter());
+            }
         }
         
         request.addQueryParam(getParamName(), value);

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/AxisOrderSwapFilter.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/AxisOrderSwapFilter.java
@@ -1,0 +1,26 @@
+package fi.nls.hakunapi.core.util;
+
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFilter;
+
+public class AxisOrderSwapFilter implements CoordinateSequenceFilter {
+
+    @Override
+    public void filter(CoordinateSequence seq, int i) {
+        final double x = seq.getX(i);
+        final double y = seq.getY(i);
+        seq.setOrdinate(i, CoordinateSequence.X, y);
+        seq.setOrdinate(i, CoordinateSequence.Y, x);
+    }
+
+    @Override
+    public boolean isDone() {
+        return false;
+    }
+
+    @Override
+    public boolean isGeometryChanged() {
+        return true;
+    }
+
+}

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxCrsParamTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxCrsParamTest.java
@@ -1,0 +1,110 @@
+package fi.nls.hakunapi.core.param;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+
+import fi.nls.hakunapi.core.FeatureProducer;
+import fi.nls.hakunapi.core.FeatureServiceConfig;
+import fi.nls.hakunapi.core.FeatureType;
+import fi.nls.hakunapi.core.OutputFormat;
+import fi.nls.hakunapi.core.PaginationStrategyOffset;
+import fi.nls.hakunapi.core.SimpleFeatureType;
+import fi.nls.hakunapi.core.filter.Filter;
+import fi.nls.hakunapi.core.property.simple.HakunaPropertyGeometry;
+import fi.nls.hakunapi.core.request.GetFeatureCollection;
+import fi.nls.hakunapi.core.request.GetFeatureRequest;
+import fi.nls.hakunapi.core.schemas.Crs;
+
+public class BboxCrsParamTest {
+
+    private SimpleFeatureType myCollection;
+    private FeatureServiceConfig service;
+
+    @Before
+    public void init() {
+        myCollection = new SimpleFeatureType() {
+
+            @Override
+            public FeatureProducer getFeatureProducer() {
+                return null;
+            }
+        };
+        myCollection.setName("myCollection");
+        myCollection.setProperties(Collections.emptyList());
+        myCollection.setStaticFilters(Collections.emptyList());
+        myCollection.setGeom(new HakunaPropertyGeometry("geometry", "table", null, false, null, new int[0], 84, 2, (__, ___, ____) -> {}));
+        myCollection.setPaginationStrategy(PaginationStrategyOffset.INSTANCE);
+
+        service = new FeatureServiceConfig() {
+
+            @Override
+            public Collection<OutputFormat> getOutputFormats() {
+                return null;
+            }
+
+            @Override
+            public OutputFormat getOutputFormat(String f) {
+                return null;
+            }
+
+            @Override
+            public Collection<FeatureType> getCollections() {
+                return Arrays.asList(myCollection);
+            }
+
+            @Override
+            public FeatureType getCollection(String name) {
+                return myCollection.getName().equals(name) ? myCollection : null;
+            }
+        };
+    }
+
+    @Test
+    public void testLonLatRS84() {
+        GetFeatureRequest req = new GetFeatureRequest();
+        GetFeatureCollection getItems = new GetFeatureCollection(myCollection);
+        req.addCollection(getItems);
+
+        new BboxParam().modify(service, req, "-180,-90,180,90");
+        new BboxCrsParam().modify(service, req, Crs.CRS84);
+
+        List<Filter> filters = getItems.getFilters();
+        assertEquals(1, filters.size());
+        Filter filter = filters.get(0);
+        Geometry geom = (Geometry) filter.getValue();
+        assertEquals(84, geom.getSRID());
+        Coordinate bottomLeft = geom.getCoordinates()[0];
+        assertEquals(-180, bottomLeft.getX(), 0.0);
+        assertEquals(-90, bottomLeft.getY(), 0.0);
+    }
+
+    @Test
+    public void testLatLonCRS4326() {
+        GetFeatureRequest req = new GetFeatureRequest();
+        GetFeatureCollection getItems = new GetFeatureCollection(myCollection);
+        req.addCollection(getItems);
+
+        new BboxParam().modify(service, req, "-90,-180,90,180");
+        String bboxCrs = "http://www.opengis.net/def/crs/EPSG/0/4326";
+        new BboxCrsParam().modify(service, req, bboxCrs);
+
+        List<Filter> filters = getItems.getFilters();
+        assertEquals(1, filters.size());
+        Filter filter = filters.get(0);
+        Geometry geom = (Geometry) filter.getValue();
+        assertEquals(4326, geom.getSRID());
+        Coordinate bottomLeft = geom.getCoordinates()[0];
+        assertEquals(-180, bottomLeft.getX(), 0.0);
+        assertEquals(-90, bottomLeft.getY(), 0.0);
+    }
+
+}

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -78,7 +78,7 @@
         <tbody>
           <#list features as feature>
           <tr>
-            <td><a href="./items/${feature.id}" class="text-decoration-none">${feature.id}</a></td>
+            <td><a id="feature-link-${feature.id}" class="text-decoration-none">${feature.id}</a></td>
             <#list feature.properties?values as value>
             <td>${value!""}</td>
             </#list>
@@ -129,9 +129,17 @@ var data = [
 </#list>
 ];
 
+const singleFeatureLinkParams = new URLSearchParams(window.location.search);
+singleFeatureLinkParams.delete("bbox");
+singleFeatureLinkParams.delete("bbox-crs");
+singleFeatureLinkParams.delete("filter");
+const singleFeatureLinkQuery = singleFeatureLinkParams.size === 0 ? "" : "?" + singleFeatureLinkParams.toString();
+
+data.forEach(f => document.getElementById("feature-link-" + f.id).href = "items/" + f.id + singleFeatureLinkQuery);
+
 var layer = L.geoJSON(data, {
   onEachFeature: function (feature, layer) {
-    layer.bindPopup('<a href="./items/' + feature.id + '">' + feature.id + '</a>');
+    layer.bindPopup('<a href="./items/' + feature.id + singleFeatureLinkQuery + '">' + feature.id + '</a>');
   }
 }).addTo(map);
 


### PR DESCRIPTION
Perform axis order swap for cordinates of `bbox` parameter if `bbox-crs` is lat,lon system in order to maintain the principle of x == lon, y == lat while "inside" hakunapi (and perform necessary swaps while reading/writing).

Uses the functionality added in #55 to determine the axis order of a coordinate reference system.
