### PR TITLE
 Support environment variables as an alternative to any system properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
 		<log4j.version>2.19.0</log4j.version>
 		<pgjdbc.version>42.5.1</pgjdbc.version>
 		<junit.version>4.13.2</junit.version>
+		<mockito.version>4.11.0</mockito.version>
 		<cyclonedx.version>2.7.3</cyclonedx.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
@@ -259,6 +260,12 @@
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>${junit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/src/hakunapi-simple-webapp-javax/pom.xml
+++ b/src/hakunapi-simple-webapp-javax/pom.xml
@@ -89,6 +89,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -52,6 +52,7 @@ import io.swagger.v3.oas.models.servers.Server;
 public class HakunaContextListener implements ServletContextListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(HakunaContextListener.class);
+    private static final String ENV_PREFIX = "HAKUNAPI_";
 
     private List<Closeable> toClose;
 
@@ -223,9 +224,9 @@ public class HakunaContextListener implements ServletContextListener {
         return contextName;
     }
 
-    protected static Optional<Path> getConfigPath(String contextPath) {
+    protected Optional<Path> getConfigPath(String contextPath) {
         String property = contextPath + ".hakuna.config.path";
-        String hakunaConfigPath = System.getProperty(property);
+        String hakunaConfigPath = getProperty(property);
         if (hakunaConfigPath != null && !hakunaConfigPath.isEmpty()) {
             LOG.info("{} = {}", property, hakunaConfigPath);
             Path path = Paths.get(hakunaConfigPath);
@@ -238,7 +239,7 @@ public class HakunaContextListener implements ServletContextListener {
         }
 
         property = "hakuna.config.path";
-        hakunaConfigPath = System.getProperty(property);
+        hakunaConfigPath = getProperty(property);
         if (hakunaConfigPath != null && !hakunaConfigPath.isEmpty()) {
             LOG.info("{} = {}", property, hakunaConfigPath);
             Path path = Paths.get(hakunaConfigPath, contextPath + ".properties");
@@ -251,6 +252,24 @@ public class HakunaContextListener implements ServletContextListener {
         }
 
         return Optional.empty();
+    }
+
+    private String getProperty(final String property) {
+        // first check environment variables
+        final String envValue = getEnv(getEnvVariableName(property));
+        if (envValue != null && !envValue.isEmpty()) {
+            return envValue;
+        }
+        // fallback to system properties
+        return System.getProperty(property);
+    }
+
+    String getEnv(String envVariable) {
+        return System.getenv(envVariable);
+    }
+
+    private String getEnvVariableName(String property) {
+        return ENV_PREFIX + property.toUpperCase().replace('.', '_');
     }
 
     private Properties load(Path path, Charset cs) {

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -52,7 +52,6 @@ import io.swagger.v3.oas.models.servers.Server;
 public class HakunaContextListener implements ServletContextListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(HakunaContextListener.class);
-    private static final String ENV_PREFIX = "HAKUNAPI_";
 
     private List<Closeable> toClose;
 
@@ -269,7 +268,7 @@ public class HakunaContextListener implements ServletContextListener {
     }
 
     private String getEnvVariableName(String property) {
-        return ENV_PREFIX + property.toUpperCase().replace('.', '_');
+        return property.toUpperCase().replace('.', '_');
     }
 
     private Properties load(Path path, Charset cs) {

--- a/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
+++ b/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
@@ -31,12 +31,12 @@ public class HakunaContextListenerTest {
         assertEquals("Expect $key.hakuna.config.path to get preferred", barPath,
                 listener.getConfigPath("foo").get().toString());
 
-        Mockito.when(listener.getEnv("HAKUNAPI_HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
+        Mockito.when(listener.getEnv("HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
 
         assertEquals("Expect more specific system property to get preferred", barPath,
                 listener.getConfigPath("foo").get().toString());
 
-        Mockito.when(listener.getEnv("HAKUNAPI_FOO_HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
+        Mockito.when(listener.getEnv("FOO_HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
 
         assertEquals("Expect environment variable to get preferred", fooPath,
                 listener.getConfigPath("foo").get().toString());

--- a/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
+++ b/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
@@ -9,25 +9,37 @@ import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import fi.nls.hakunapi.core.config.HakunaApplicationJson;
-import fi.nls.hakunapi.simple.webapp.javax.HakunaContextListener;
 
 public class HakunaContextListenerTest {
 
     @Test
     public void testGetConfigPath() throws URISyntaxException {
+        HakunaContextListener listener = Mockito.spy(HakunaContextListener.class);
+
         String barPath = Paths.get(getClass().getClassLoader().getResource("bar.properties").toURI()).toString();
         String fooPath = Paths.get(getClass().getClassLoader().getResource("foo.properties").toURI()).toString();
         String dirPath = barPath.substring(0, barPath.lastIndexOf(FileSystems.getDefault().getSeparator()));
 
         System.setProperty("hakuna.config.path", dirPath);
         assertEquals("With only directory expect /path/$key.properties", fooPath,
-                HakunaContextListener.getConfigPath("foo").get().toString());
+                listener.getConfigPath("foo").get().toString());
 
         System.setProperty("foo.hakuna.config.path", barPath);
         assertEquals("Expect $key.hakuna.config.path to get preferred", barPath,
-                HakunaContextListener.getConfigPath("foo").get().toString());
+                listener.getConfigPath("foo").get().toString());
+
+        Mockito.when(listener.getEnv("HAKUNAPI_HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
+
+        assertEquals("Expect more specific system property to get preferred", barPath,
+                listener.getConfigPath("foo").get().toString());
+
+        Mockito.when(listener.getEnv("HAKUNAPI_FOO_HAKUNA_CONFIG_PATH")).thenReturn(fooPath);
+
+        assertEquals("Expect environment variable to get preferred", fooPath,
+                listener.getConfigPath("foo").get().toString());
     }
 
     @Test


### PR DESCRIPTION
System properties `[{context_path}.]hakuna.config.path` can now be configured via `{CONTEXT_PATH}_HAKUNA_CONFIG_PATH` or `HAKUNA_CONFIG_PATH` env variables.

env variables take higher precedence, but only within the same key, meaning in here the priority is (see the added unit test):
1) env variable `{CONTEXT_PATH}_HAKUNA_CONFIG_PATH`
2) system property `{context_path}.hakuna.config.path`
3) env variable `HAKUNA_CONFIG_PATH`
4) system property `hakuna.config.path`

Related issue #50 