### PR TITLE
Allow request headers to be used for dynamic server url

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CurrentServerUrlProvider.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CurrentServerUrlProvider.java
@@ -1,0 +1,10 @@
+package fi.nls.hakunapi.core;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface CurrentServerUrlProvider {
+
+    public String get(Function<String, String> dynamicValues);
+
+}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CurrentServerUrlProviders.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CurrentServerUrlProviders.java
@@ -1,0 +1,70 @@
+package fi.nls.hakunapi.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CurrentServerUrlProviders {
+
+    private static final char DYNAMIC_VARIABLE_INIT = '$';
+    private static final char DYNAMIC_VARIABLE_BEGIN = '{';
+    private static final char DYNAMIC_VARIABLE_END = '}';
+
+    private CurrentServerUrlProviders() {
+        // Block init
+    }
+
+    public static CurrentServerUrlProvider from(String pattern) {
+        if (pattern == null || pattern.isEmpty()) {
+            throw new IllegalArgumentException("null or empty pattern form current server url!");
+        }
+
+        List<CurrentServerUrlProvider> segments = new ArrayList<>();
+        for (int i = 0; i < pattern.length();) {
+            int[] next = getNextDynamicSegment(pattern, i);
+            if (next == null) {
+                // Rest of the pattern as-is
+                String s = pattern.substring(i);
+                if (!s.isEmpty()) {
+                    segments.add(__ -> s);
+                }
+                break;
+            }
+            if (next[0] != i) {
+                String s = pattern.substring(i, next[0]);
+                segments.add(__ -> s);
+            }
+            String key = pattern.substring(next[0] + 2, next[1]);
+            segments.add(values -> values.apply(key));
+            i = next[1] + 1;
+        }
+
+        if (segments.size() < 2) {
+            return segments.get(0);
+        }
+
+        return values -> {
+            // Stream#reduce would require separate combiner function, for-loop for the win
+            StringBuilder sb = new StringBuilder();
+            for (CurrentServerUrlProvider segment : segments) {
+                sb.append(segment.get(values));
+            }
+            return sb.toString();
+        };
+    }
+
+    static int[] getNextDynamicSegment(String pattern, int fromIndex) {
+        int i = pattern.indexOf(DYNAMIC_VARIABLE_INIT, fromIndex);
+        if (i < 0) {
+            return null;
+        }
+        if (pattern.charAt(i + 1) != DYNAMIC_VARIABLE_BEGIN) {
+            return null;
+        }
+        int j = pattern.indexOf(DYNAMIC_VARIABLE_END, i + 2);
+        if (j < 0 || j == i + 2) {
+            return null;
+        }
+        return new int[] { i, j };
+    }
+
+}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/request/GetFeatureRequest.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/request/GetFeatureRequest.java
@@ -20,6 +20,7 @@ public class GetFeatureRequest {
     private int filterSrid = Crs.CRS84_SRID;
     private Map<String, String> pathParams;
     private Map<String, String> queryParams;
+    private Map<String, String> queryHeaders;
     private Map<String, String> responseHeaders;
 
     public OutputFormat getFormat() {
@@ -109,6 +110,14 @@ public class GetFeatureRequest {
             queryParams = new HashMap<>();
         }
         queryParams.put(key, value);
+    }
+
+    public Map<String, String> getQueryHeaders() {
+        return queryHeaders;
+    }
+
+    public void setQueryHeaders(Map<String, String> queryHeaders) {
+        this.queryHeaders = queryHeaders;
     }
 
     public Map<String, String> getResponseHeaders() {

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/CurrentServerUrlProvidersTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/CurrentServerUrlProvidersTest.java
@@ -1,0 +1,51 @@
+package fi.nls.hakunapi.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class CurrentServerUrlProvidersTest {
+
+    @Test
+    public void testStatic() {
+        String pattern = "http://www.domain.com/features";
+        String expected = pattern;
+        assertEquals(expected, CurrentServerUrlProviders.from(pattern).get(__ -> null));
+    }
+
+    @Test
+    public void testDynamic() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Forwarded-Host", "www.domain.com");
+
+        String pattern = "https://${X-Forwarded-Host}/features";
+        String expected = "https://www.domain.com/features";
+        assertEquals(expected, CurrentServerUrlProviders.from(pattern).get(headers::get));
+    }
+
+    @Test
+    public void testStartsWithDynamic() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Forwarded-Proto", "https");
+        headers.put("X-Forwarded-Host", "www.domain.com");
+
+        String pattern = "${X-Forwarded-Proto}://${X-Forwarded-Host}/features";
+        String expected = "https://www.domain.com/features";
+        assertEquals(expected, CurrentServerUrlProviders.from(pattern).get(headers::get));
+    }
+
+    @Test
+    public void testEndsWithDynamic() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-Forwarded-Host", "www.domain.com");
+        headers.put("X-Forwarded-Path", "not-features");
+
+        String pattern = "https://${X-Forwarded-Host}/${X-Forwarded-Path}";
+        String expected = "https://www.domain.com/not-features";
+        assertEquals(expected, CurrentServerUrlProviders.from(pattern).get(headers::get));
+    }
+
+}

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLContext.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLContext.java
@@ -5,15 +5,27 @@ import fi.nls.hakunapi.core.FeatureServiceConfig;
 public class HTMLContext<T> {
 
     private final FeatureServiceConfig service;
+    private final String basePath;
+    private final String basePathTrailingSlash;
     private final T model;
 
-    public HTMLContext(FeatureServiceConfig service, T model) {
+    public HTMLContext(FeatureServiceConfig service, String basePath, T model) {
         this.service = service;
+        this.basePath = basePath;
+        this.basePathTrailingSlash = basePath + (basePath.endsWith("/") ? "" : "/");
         this.model = model;
     }
 
     public FeatureServiceConfig getService() {
         return service;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public String getBasePathTrailingSlash() {
+        return basePathTrailingSlash;
     }
 
     public T getModel() {

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/api.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/api.ftl
@@ -32,7 +32,7 @@ img[alt="Swagger UI"] { display: none; }
 window.onload = function() {
 window.ui = SwaggerUIBundle({
 dom_id: '#swagger-ui',
-url: "${service.currentServerURL}/api.json",
+url: "${basePathTrailingSlash}api.json",
 deepLinking: true,
 presets: [SwaggerUIBundle.presets.apis],
 plugins: [],

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
@@ -5,14 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <title>${service.title!""} - ${(model.title)!(model.id)}</title>
+  <base href="${basePathTrailingSlash}">
 </head>
 <body>
 <main>
   <div class="container-lg py-4">
     <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections">Collections</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${basePathTrailingSlash}">Home</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="collections">Collections</a></li>
         <li class="breadcrumb-item active" aria-current="page">${model.title!model.id}</li>
       </ol>
       <ul class="nav">
@@ -33,7 +34,7 @@
     </header>
 
     <h2>Items</h2>
-    <p><a href="${service.currentServerURL}/collections/${model.id}/items">Browse features in the collection</a></p>
+    <p><a href="collections/${model.id}/items">Browse features in the collection</a></p>
    
     <#if model.crs??>
     <h3>Supported Coordinate Reference Systems</h3>
@@ -50,7 +51,7 @@
     </#if>
     
     <h3>Queryable properties</h3>
-    <p><a href="${service.currentServerURL}/collections/${model.id}/queryables">Find out properties usable in filters</a></p>
+    <p><a href="collections/${model.id}/queryables">Find out properties usable in filters</a></p>
 
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
   </div>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
@@ -5,13 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <title>${service.title!""} - Collections</title>
+  <base href="${basePathTrailingSlash}">
 </head>
 <body>
 <main>
   <div class="container-lg py-4">
     <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${basePathTrailingSlash}">Home</a></li>
         <li class="breadcrumb-item active" aria-current="page">Collections</li>
       </ol>
       <ul class="nav">
@@ -33,7 +34,7 @@
     
     <ul>
       <#list model.collections as collection>
-      <li><a href="${service.currentServerURL}/collections/${collection.id}">${(collection.title)!(collection.id)}</a></li>
+      <li><a href="collections/${collection.id}">${(collection.title)!(collection.id)}</a></li>
       </#list>
     </ul>
     

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
@@ -5,13 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <title>${service.title!""} - Conformance</title>
+  <base href="${basePathTrailingSlash}">
 </head>
 <body>
 <main>
   <div class="container-lg py-4">
     <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${basePathTrailingSlash}">Home</a></li>
         <li class="breadcrumb-item active" aria-current="page">Conformance</li>
       </ol>
       <ul class="nav">

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
@@ -5,15 +5,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <title>${service.title!""} - ${(model.title)!(model.collectionId)} queryables</title>
+  <base href="${basePathTrailingSlash}">
 </head>
 <body>
 <main>
   <div class="container-lg py-4">
     <nav class="nav justify-content-between" aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}">Home</a></li>
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections">Collections</a></li>
-        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${service.currentServerURL}/collections/${model.collectionId}">${(model.title)!(model.collectionId)}</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="${basePathTrailingSlash}">Home</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="collections">Collections</a></li>
+        <li class="breadcrumb-item"><a class="d-flex align-items-center text-dark text-decoration-none" href="collections/${model.collectionId}">${(model.title)!(model.collectionId)}</a></li>
         <li class="breadcrumb-item active" aria-current="page">Queryables</li>
       </ol>
       <ul class="nav">

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
   <title>${model.title!""} - Home</title>
+  <base href="${basePathTrailingSlash}">
 </head>
 <body>
 <main>
@@ -32,18 +33,18 @@
     
     <div class="row">
       <h2>Collections</h2>
-      <p><a href="${service.currentServerURL}/collections">Access the data</a></p>
+      <p><a href="collections">Access the data</a></p>
     </div>
 
     <div class="row">
       <h2>API Information</h2>
-      <p><a href="${service.currentServerURL}/api.json">OpenAPI 3.0 definition</a></p>
-      <p><a href="${service.currentServerURL}/api.html">Documentation</a></p>
+      <p><a href="api.json">OpenAPI 3.0 definition</a></p>
+      <p><a href="api.html">Documentation</a></p>
     </div>
     
     <div class="row">
       <h2>Conformance</h2>
-      <p><a href="${service.currentServerURL}/conformance">OGC API conformance classes implemented by this server</a></p>
+      <p><a href="conformance">OGC API conformance classes implemented by this server</a></p>
     </div>
     
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataImpl.java
@@ -46,7 +46,8 @@ public class CollectionMetadataImpl {
             @PathParam("collectionId") String collectionId,
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers) {
-        return new HTMLContext<>(service, handle(collectionId, uriInfo, headers));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, handle(collectionId, uriInfo, headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataImpl.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
@@ -26,20 +27,26 @@ public class CollectionMetadataImpl {
     @GET
     @Path("/{collectionId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public CollectionInfo handle(@PathParam("collectionId") String collectionId, @Context UriInfo uriInfo) {
+    public CollectionInfo handle(
+            @PathParam("collectionId") String collectionId,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
         FeatureType ft = service.getCollection(collectionId);
         if (ft == null) {
             throw new NotFoundException("Unknown collection");
         }
         Map<String, String> queryParams = OperationUtil.getQueryParams(service, uriInfo);
-        return CollectionMetadataUtil.toCollectionInfo(service, ft, queryParams);
+        return CollectionMetadataUtil.toCollectionInfo(headers, service, ft, queryParams);
     }
     
     @GET
     @Path("/{collectionId}")
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<CollectionInfo> handleHTML(@PathParam("collectionId") String collectionId, @Context UriInfo uriInfo) {
-        return new HTMLContext<>(service, handle(collectionId, uriInfo));
+    public HTMLContext<CollectionInfo> handleHTML(
+            @PathParam("collectionId") String collectionId,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
+        return new HTMLContext<>(service, handle(collectionId, uriInfo, headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataUtil.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionMetadataUtil.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.HttpHeaders;
+
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.FeatureServiceConfig;
@@ -22,7 +24,7 @@ public class CollectionMetadataUtil {
     
     private static final String ITEMS_REL = "items";
 
-    public static CollectionInfo toCollectionInfo(FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams) {
+    public static CollectionInfo toCollectionInfo(HttpHeaders headers, FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams) {
         String id = ft.getName();
         String title = ft.getTitle();
         String description = ft.getDescription();
@@ -30,18 +32,18 @@ public class CollectionMetadataUtil {
         List<Link> links = new ArrayList<>();
         // /collections/{collectionId}/items
         for (OutputFormat f : service.getOutputFormats()) {
-            links.add(getItemsLink(service, queryParams, ft, f));
+            links.add(getItemsLink(headers, service, queryParams, ft, f));
         }
 
         // /collections/{collectionId}/items?f={format}
         for (OutputFormat f : service.getOutputFormats()) {
             queryParams.put("f", f.getId());
-            links.add(getItemsLink(service, queryParams, ft, f));
+            links.add(getItemsLink(headers, service, queryParams, ft, f));
             queryParams.remove("f");
         }
 
-        links.add(getDescribedByLink(service, queryParams, ft));
-        links.add(getQueryablesLinks(service, queryParams, ft));
+        links.add(getDescribedByLink(headers, service, queryParams, ft));
+        links.add(getQueryablesLinks(headers, service, queryParams, ft));
 
         String[] crs = null;
         String storageCrs = null;
@@ -66,48 +68,48 @@ public class CollectionMetadataUtil {
     }
 
     @Deprecated
-    public static Link getItemsLink(FeatureServiceConfig service, FeatureType ft, String mimeType) {
+    public static Link getItemsLink(HttpHeaders headers, FeatureServiceConfig service, FeatureType ft, String mimeType) {
         String path = "/collections/" + ft.getName() + "/items";
-        String href = service.getCurrentServerURL() + path;
+        String href = service.getCurrentServerURL(headers::getHeaderString) + path;
         String rel = ITEMS_REL;
         String type = mimeType;
         return new Link(href, rel, type);
     }
 
     @Deprecated
-    public static Link getItemsLinkWithF(FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams, OutputFormat format) {
+    public static Link getItemsLinkWithF(HttpHeaders headers, FeatureServiceConfig service, FeatureType ft, Map<String, String> queryParams, OutputFormat format) {
         queryParams.put("f", format.getId());
         String query = U.toQuery(queryParams);
         String path = "/collections/" + ft.getName() + "/items" + query;
-        String href = service.getCurrentServerURL() + path;
+        String href = service.getCurrentServerURL(headers::getHeaderString) + path;
         String rel = ITEMS_REL;
         String type = format.getMimeType();
         queryParams.remove("f");
         return new Link(href, rel, type);
     }
 
-    private static Link getItemsLink(FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft, OutputFormat format) {
+    private static Link getItemsLink(HttpHeaders headers, FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft, OutputFormat format) {
         String query = U.toQuery(queryParams);
         String path = "/collections/" + ft.getName() + "/items" + query;
-        String href = service.getCurrentServerURL() + path;
+        String href = service.getCurrentServerURL(headers::getHeaderString) + path;
         String rel = ITEMS_REL;
         String type = format.getMimeType();
         return new Link(href, rel, type);
     }
     
-    private static Link getDescribedByLink(FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft) {
+    private static Link getDescribedByLink(HttpHeaders headers, FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft) {
         String query = U.toQuery(queryParams);
         String path = "/collections/" + ft.getName() + "/schema" + query;
-        String href = service.getCurrentServerURL() + path;
+        String href = service.getCurrentServerURL(headers::getHeaderString) + path;
         String rel = "describedBy";
         String type = "application/schema+json";
         return new Link(href, rel, type);
     }
 
-    private static Link getQueryablesLinks(FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft) {
+    private static Link getQueryablesLinks(HttpHeaders headers, FeatureServiceConfig service, Map<String, String> queryParams, FeatureType ft) {
         String query = U.toQuery(queryParams);
         String path = "/collections/" + ft.getName() + "/queryables" + query;
-        String href = service.getCurrentServerURL() + path;
+        String href = service.getCurrentServerURL(headers::getHeaderString) + path;
         String rel = "http://www.opengis.net/def/rel/ogc/1.0/queryables";
         String type = "application/schema+json";
         return new Link(href, rel, type);

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
@@ -10,12 +10,13 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
+import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.MetadataFormat;
-import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.schemas.CollectionInfo;
 import fi.nls.hakunapi.core.schemas.CollectionsContent;
 import fi.nls.hakunapi.core.schemas.Link;
@@ -30,27 +31,27 @@ public class CollectionsMetadataImpl {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public CollectionsContent handleJSON(@Context UriInfo uriInfo) {
-        return handle(uriInfo, MediaType.APPLICATION_JSON);
+    public CollectionsContent handleJSON(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
+        return handle(uriInfo, headers, MediaType.APPLICATION_JSON);
     }
 
     @GET
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<CollectionsContent> handleHTML(@Context UriInfo uriInfo) {
-        return new HTMLContext<>(service, handle(uriInfo, MediaType.TEXT_HTML));
+    public HTMLContext<CollectionsContent> handleHTML(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
+        return new HTMLContext<>(service, handle(uriInfo, headers, MediaType.TEXT_HTML));
     }
 
-    private CollectionsContent handle(UriInfo uriInfo, String contentType) {
+    private CollectionsContent handle(UriInfo uriInfo, HttpHeaders headers, String contentType) {
         Map<String, String> queryParams = OperationUtil.getQueryParams(service, uriInfo);
 
-        String path = service.getCurrentServerURL() + "/collections";
+        String path = service.getCurrentServerURL(headers::getHeaderString) + "/collections";
         List<Link> links = new ArrayList<>();
         links.add(Links.getSelfLink(path, queryParams, contentType));
         links.addAll(getAlternateLinks(path, queryParams, contentType));
 
         List<CollectionInfo> collections = new ArrayList<>();
         for (FeatureType ft : service.getCollections()) {
-            CollectionInfo info = CollectionMetadataUtil.toCollectionInfo(service, ft, queryParams);
+            CollectionInfo info = CollectionMetadataUtil.toCollectionInfo(headers, service, ft, queryParams);
             collections.add(info);
         }
 

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/CollectionsMetadataImpl.java
@@ -38,7 +38,8 @@ public class CollectionsMetadataImpl {
     @GET
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<CollectionsContent> handleHTML(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
-        return new HTMLContext<>(service, handle(uriInfo, headers, MediaType.TEXT_HTML));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, handle(uriInfo, headers, MediaType.TEXT_HTML));
     }
 
     private CollectionsContent handle(UriInfo uriInfo, HttpHeaders headers, String contentType) {

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/ConformanceImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/ConformanceImpl.java
@@ -4,6 +4,8 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import fi.nls.hakunapi.core.FeatureServiceConfig;
@@ -24,8 +26,9 @@ public class ConformanceImpl {
 
     @GET
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<ConformanceClasses> handleHTML() {
-        return new HTMLContext<>(service, new ConformanceClasses(service.getConformanceClasses()));
+    public HTMLContext<ConformanceClasses> handleHTML(@Context HttpHeaders headers) {
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, new ConformanceClasses(service.getConformanceClasses()));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
@@ -24,13 +24,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import fi.nls.hakunapi.core.FeatureProducer;
+import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.FeatureStream;
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.FeatureWriter;
 import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.SingleFeatureWriter;
 import fi.nls.hakunapi.core.ValueProvider;
-import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.core.operation.DynamicPathOperation;
 import fi.nls.hakunapi.core.operation.DynamicResponseOperation;
@@ -111,7 +111,8 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
             request.setFormat(OperationUtil.determineOutputFormat(wsRequest, service.getOutputFormats()));
             request.addCollection(c);
             request.addPathParam("collectionId", collectionId);
-            
+            request.setQueryHeaders(OperationUtil.toSimpleMap(headers.getRequestHeaders()));
+
             c.addFilter(Filter.equalTo(ft.getId(), featureId));
             request.addPathParam("featureId", featureId);
 
@@ -173,12 +174,13 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
 
     public List<Link> getLinks(GetFeatureRequest request, FeatureWriter writer) {
         Map<String, String> queryParams = request.getQueryParams();
+        Map<String, String> queryHeaders = request.getQueryHeaders();
 
         String collectionId = request.getPathParam("collectionId");
         String featureId = request.getPathParam("featureId");
         String mimeType = writer.getMimeType();
 
-        String itemsPath = Links.getItemsPath(service.getCurrentServerURL(), collectionId);
+        String itemsPath = Links.getItemsPath(service.getCurrentServerURL(queryHeaders::get), collectionId);
         String featurePath = itemsPath + "/" + featureId;
 
         List<Link> links = new ArrayList<>();

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
@@ -47,7 +47,8 @@ public class GetCollectionQueryablesImpl {
             @PathParam("collectionId") String collectionId,
             @Context UriInfo uriInfo,
             @Context HttpHeaders headers) {
-        return new HTMLContext<>(service, handle(collectionId, uriInfo, headers));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, handle(collectionId, uriInfo, headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
@@ -24,12 +25,15 @@ public class GetCollectionQueryablesImpl {
 
     @GET
     @Produces("application/schema+json")
-    public Queryables handle(@PathParam("collectionId") String collectionId, @Context UriInfo uriInfo) {
+    public Queryables handle(
+            @PathParam("collectionId") String collectionId,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
         FeatureType ft = service.getCollection(collectionId);
         if (ft == null) {
             throw new NotFoundException("Unknown collection");
         }
-        String id = String.format("%s/collections/%s/queryables", service.getCurrentServerURL(), collectionId);
+        String id = String.format("%s/collections/%s/queryables", service.getCurrentServerURL(headers::getHeaderString), collectionId);
         Queryables queryables = new Queryables(ft.getName(), id, ft.getTitle(), ft.getDescription());
         for (HakunaProperty queryable : ft.getQueryableProperties()) {
             queryables.addProperty(queryable.getName(), queryable.getSchema());
@@ -39,8 +43,11 @@ public class GetCollectionQueryablesImpl {
 
     @GET
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<Queryables> handleHTML(@PathParam("collectionId") String collectionId, @Context UriInfo uriInfo) {
-        return new HTMLContext<>(service, handle(collectionId, uriInfo));
+    public HTMLContext<Queryables> handleHTML(
+            @PathParam("collectionId") String collectionId,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
+        return new HTMLContext<>(service, handle(collectionId, uriInfo, headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionSchemaImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionSchemaImpl.java
@@ -8,6 +8,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.UriInfo;
 
 import fi.nls.hakunapi.core.FeatureType;
@@ -32,13 +33,16 @@ public class GetCollectionSchemaImpl {
     @GET
     @Path("/{collectionId}/schema")
     @Produces("application/schema+json")
-    public SchemaDefinition handle(@PathParam("collectionId") String collectionId, @Context UriInfo uriInfo) {
+    public SchemaDefinition handle(
+            @PathParam("collectionId") String collectionId,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders headers) {
         FeatureType ft = service.getCollection(collectionId);
         if (ft == null) {
             return null;
         }
 
-        String id = String.format("%s/collections/%s/schema", service.getCurrentServerURL(), collectionId);
+        String id = String.format("%s/collections/%s/schema", service.getCurrentServerURL(headers::getHeaderString), collectionId);
         String title = "Schema for " + (ft.getTitle() != null ? ft.getTitle() : ft.getId());
         String description = "JSON Schema describing the properties for each feature";
 

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
@@ -137,9 +137,11 @@ public class GetItemsOperation implements ParametrizedOperation, DynamicResponse
     }
 
     public List<Link> getLinks(GetFeatureRequest request, FeatureCollectionWriter writer, NextCursor cursor, List<GetFeatureCollection> remainingCollections) {
-        String path = service.getCurrentServerURL() + "/items";
-        String mimeType = writer.getMimeType();
         Map<String, String> queryParams = request.getQueryParams();
+        Map<String, String> queryHeaders = request.getQueryHeaders();
+
+        String path = service.getCurrentServerURL(queryHeaders::get) + "/items";
+        String mimeType = writer.getMimeType();
 
         List<Link> links = new ArrayList<>();
 

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/LandingPageImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/LandingPageImpl.java
@@ -28,7 +28,8 @@ public class LandingPageImpl {
     @GET
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<Root> handleHTML(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
-        return new HTMLContext<>(service, handle(uriInfo, headers, MediaType.TEXT_HTML, MediaType.APPLICATION_JSON));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, handle(uriInfo, headers, MediaType.TEXT_HTML, MediaType.APPLICATION_JSON));
     }
     
     private Root handle(UriInfo uriInfo, HttpHeaders headers, String contentType, String alternateContentType) {

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/LandingPageImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/LandingPageImpl.java
@@ -5,6 +5,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
@@ -20,20 +21,20 @@ public class LandingPageImpl {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Root handleJSON(@Context UriInfo uriInfo) {
-        return handle(uriInfo, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML);
+    public Root handleJSON(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
+        return handle(uriInfo, headers, MediaType.APPLICATION_JSON, MediaType.TEXT_HTML);
     }
     
     @GET
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<Root> handleHTML(@Context UriInfo uriInfo) {
-        return new HTMLContext<>(service, handle(uriInfo, MediaType.TEXT_HTML, MediaType.APPLICATION_JSON));
+    public HTMLContext<Root> handleHTML(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
+        return new HTMLContext<>(service, handle(uriInfo, headers, MediaType.TEXT_HTML, MediaType.APPLICATION_JSON));
     }
     
-    private Root handle(UriInfo uriInfo, String contentType, String alternateContentType) {
+    private Root handle(UriInfo uriInfo, HttpHeaders headers, String contentType, String alternateContentType) {
         String title = service.getTitle();
         String description = service.getDescription();
-        String url = service.getCurrentServerURL();
+        String url = service.getCurrentServerURL(headers::getHeaderString);
         String query = OperationUtil.getQuery(service, uriInfo);
         
         return new Root.Builder(title, description, url, query, contentType)

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
@@ -6,6 +6,8 @@ import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
 import fi.nls.hakunapi.core.FeatureServiceConfig;
@@ -28,29 +30,29 @@ public class OpenAPI30ApiOperation {
     @GET
     @Path("/api")
     @Produces("application/vnd.oai.openapi+json;version=3.0")
-    public OpenAPI json() {
-        return api.create();
+    public OpenAPI json(@Context HttpHeaders headers) {
+        return api.create(headers);
     }
 
     @GET
     @Path("/api.json")
     @Produces("application/vnd.oai.openapi+json;version=3.0")
-    public OpenAPI jsonExt() {
-        return api.create();
+    public OpenAPI jsonExt(@Context HttpHeaders headers) {
+        return api.create(headers);
     }
     
     @GET
     @Path("/api")
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<OpenAPI> html() {
-        return new HTMLContext<>(service, api.create());
+    public HTMLContext<OpenAPI> html(@Context HttpHeaders headers) {
+        return new HTMLContext<>(service, api.create(headers));
     }
     
     @GET
     @Path("/api.html")
     @Produces(MediaType.TEXT_HTML)
-    public HTMLContext<OpenAPI> htmlExt() {
-        return new HTMLContext<>(service, api.create());
+    public HTMLContext<OpenAPI> htmlExt(@Context HttpHeaders headers) {
+        return new HTMLContext<>(service, api.create(headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
@@ -45,14 +45,16 @@ public class OpenAPI30ApiOperation {
     @Path("/api")
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<OpenAPI> html(@Context HttpHeaders headers) {
-        return new HTMLContext<>(service, api.create(headers));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, api.create(headers));
     }
     
     @GET
     @Path("/api.html")
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<OpenAPI> htmlExt(@Context HttpHeaders headers) {
-        return new HTMLContext<>(service, api.create(headers));
+        String basePath = service.getCurrentServerURL(headers::getHeaderString);
+        return new HTMLContext<>(service, basePath, api.create(headers));
     }
 
 }

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30Generator.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30Generator.java
@@ -14,6 +14,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import fi.nls.hakunapi.core.FeatureServiceConfig;
@@ -46,6 +47,7 @@ import io.swagger.v3.oas.models.parameters.PathParameter;
 import io.swagger.v3.oas.models.parameters.QueryParameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 
 public class OpenAPI30Generator {
@@ -62,10 +64,21 @@ public class OpenAPI30Generator {
         this._components = new HashMap<>();
     }
 
-    public OpenAPI create() {
+    public OpenAPI create(HttpHeaders headers) {
+        Server server = service.getServer();
+        String url = service.getCurrentServerURL(headers::getHeaderString);
+        if (!url.equals(server.getUrl())) {
+            Server tmp = new Server();
+            tmp.setUrl(url);
+            tmp.setDescription(server.getDescription());
+            tmp.setExtensions(server.getExtensions());
+            tmp.setVariables(server.getVariables());
+            server = tmp;
+        }
+
         OpenAPI openApi = new OpenAPI();
         openApi.info(service.getInfo());
-        openApi.servers(service.getServers());
+        openApi.servers(Arrays.asList(server));
         openApi.tags(getTags());
         openApi.paths(getPaths());
         openApi.components(new Components()

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OperationUtil.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OperationUtil.java
@@ -4,15 +4,17 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Variant;
 
-import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.FeatureServiceConfig;
+import fi.nls.hakunapi.core.OutputFormat;
 import fi.nls.hakunapi.core.util.U;
 
 public class OperationUtil {
@@ -48,6 +50,13 @@ public class OperationUtil {
             }
         }
         return null;
+    }
+
+    public static Map<String, String> toSimpleMap(MultivaluedMap<String, String> requestHeaders) {
+        // Create case insensitive map
+        Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        requestHeaders.forEach((k, v) -> headers.put(k, v.get(0)));
+        return headers;
     }
 
 }


### PR DESCRIPTION
Related issue #50

Allow request headers to be used when determining current server url.

Deprecates `FeatureServiceConfig#getCurrentServerUrl()` in favor of `FeatureServiceConfig#getCurrentServerUrl(Function<String, String> dynamicValues)`.
Also dropped support for multiple server definitions in OpenAPI document which probably wasn't used by anyone.

Fixed multiple issues with default HTML templates where relative links broke weren't when directly accessing non-root path with trailing slash, e.g. `/myapi/collections/`

Example configuration used in testing:
```
servers.dev.url=http://${X-Forwarded-Host}/${X-Forwarded-Path}
# the old static way still works as expected
# servers.dev.url=http://localhost:8080/features
```
No http header is off limits. Http header names are handled case-insensitively as highlighted by the nginx config snippet below.

Tested with simple nginx running as reverse proxy on port 80 with hakunapi running on tomcat on port 8080.
Snippet of used config:
```
location /features/v1 {
	proxy_pass http://localhost:8080/features;
	proxy_set_header x-FORWARDED-host $host;
	proxy_set_header x-forwarded-PATH features/v1;
}
```

HTML view of single feature:
![image](https://github.com/nlsfi/hakunapi/assets/2799041/7720436b-8a87-4aea-aff9-f3f3ab67127b)

GeoJSON FeatureCollection with customized links:
![image](https://github.com/nlsfi/hakunapi/assets/2799041/aff47d8b-b18e-478e-89e0-1e7ae3d6d5be)
