### PR TITLE
Add [{context_path}.]hakunapi.config.path variants

### DIFF
--- a/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
+++ b/src/hakunapi-simple-webapp-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListenerTest.java
@@ -1,6 +1,7 @@
 package fi.nls.hakunapi.simple.webapp.javax;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +41,41 @@ public class HakunaContextListenerTest {
 
         assertEquals("Expect environment variable to get preferred", fooPath,
                 listener.getConfigPath("foo").get().toString());
+
+        // Cleanup
+        System.clearProperty("hakuna.config.path");
+        System.clearProperty("foo.hakuna.config.path");
+    }
+
+    @Test
+    public void testGetConfigPathHakunapi() throws URISyntaxException {
+        HakunaContextListener listener = Mockito.spy(HakunaContextListener.class);
+
+        String fooPath = Paths.get(getClass().getClassLoader().getResource("foo.properties").toURI()).toString();
+        String barPath = Paths.get(getClass().getClassLoader().getResource("bar.properties").toURI()).toString();
+
+        assertTrue(listener.getConfigPath("foo").isEmpty());
+        assertTrue(listener.getConfigPath("bar").isEmpty());
+
+        System.setProperty("hakunapi.config.path", barPath);
+        assertEquals(barPath, listener.getConfigPath("foo").get().toString());
+        assertEquals(barPath, listener.getConfigPath("bar").get().toString());
+
+        Mockito.when(listener.getEnv("HAKUNAPI_CONFIG_PATH")).thenReturn(fooPath);
+        assertEquals(fooPath, listener.getConfigPath("foo").get().toString());
+        assertEquals(fooPath, listener.getConfigPath("bar").get().toString());
+
+        System.setProperty("bar.hakunapi.config.path", barPath);
+        assertEquals(fooPath, listener.getConfigPath("foo").get().toString());
+        assertEquals(barPath, listener.getConfigPath("bar").get().toString());
+
+        Mockito.when(listener.getEnv("BAR_HAKUNAPI_CONFIG_PATH")).thenReturn(fooPath);
+        assertEquals(fooPath, listener.getConfigPath("foo").get().toString());
+        assertEquals(fooPath, listener.getConfigPath("bar").get().toString());
+
+        // Cleanup
+        System.clearProperty("hakunapi.config.path");
+        System.clearProperty("bar.hakunapi.config.path");
     }
 
     @Test


### PR DESCRIPTION
#62 added support for using environment variables to be used for setting hakuna.config.path.

This PR adds support for two new properties which are more in line with the projects current name:
1) `{CONTEXT_PATH}_HAKUNAPI_CONFIG_PATH` and `{context_path}.hakunapi.config.path`
2) `HAKUNAPI_CONFIG_PATH` and `hakunapi.config.path`

Doesn't break or change anything and doesn't force anyone to migrate.

For `hakuna.config.path` users, when migrating do take note of the fact that `hakunapi.config.path` and `hakuna.config.path` work in totally different ways:
* `hakuna.config.path` uses the provided path as a directory and then the current context_path as the filename
  * e.g. `{hakuna.config.path}/{context_path}.properties`
* `hakunapi.config.path` is much simpler, it uses the provided path as is
  * e.g. `{hakunapi.config.path}`

This is by-design so that the users don't have to care about the context path when deploying a single instance of hakunapi in one servlet container. 