### PR TITLE
Placeholders in configuration

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/HakunapiPlaceholder.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/HakunapiPlaceholder.java
@@ -1,0 +1,76 @@
+package fi.nls.hakunapi.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HakunapiPlaceholder {
+
+    private static final char DYNAMIC_VARIABLE_INIT = '$';
+    private static final char DYNAMIC_VARIABLE_BEGIN = '{';
+    private static final char DYNAMIC_VARIABLE_END = '}';
+
+    private HakunapiPlaceholder() {
+        // Block init
+    }
+
+    public static List<PlaceholderSegment> parseSegments(String pattern) {
+        List<PlaceholderSegment> segments = new ArrayList<>();
+
+        for (int i = 0; i < pattern.length();) {
+            int[] next = getNextDynamicSegment(pattern, i);
+            if (next == null) {
+                // Rest of the pattern as-is
+                String s = pattern.substring(i);
+                if (!s.isEmpty()) {
+                    segments.add(new PlaceholderSegment(s, false));
+                }
+                break;
+            }
+            if (next[0] != i) {
+                String s = pattern.substring(i, next[0]);
+                segments.add(new PlaceholderSegment(s, false));
+            }
+            String key = pattern.substring(next[0] + 2, next[1]);
+            segments.add(new PlaceholderSegment(key, true));
+            i = next[1] + 1;
+        }
+
+        return segments;
+    }
+
+    private static int[] getNextDynamicSegment(String pattern, int fromIndex) {
+        int i = pattern.indexOf(DYNAMIC_VARIABLE_INIT, fromIndex);
+        if (i < 0) {
+            return null;
+        }
+        if (pattern.charAt(i + 1) != DYNAMIC_VARIABLE_BEGIN) {
+            return null;
+        }
+        int j = pattern.indexOf(DYNAMIC_VARIABLE_END, i + 2);
+        if (j < 0 || j == i + 2) {
+            return null;
+        }
+        return new int[] { i, j };
+    }
+
+    public static final class PlaceholderSegment {
+
+        private final String value;
+        private final boolean placeholder;
+
+        private PlaceholderSegment(String value, boolean placeholder) {
+            this.value = value;
+            this.placeholder = placeholder;
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public boolean isPlaceholder() {
+            return placeholder;
+        }
+
+    }
+
+}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fi.nls.hakunapi.core.CacheSettings;
 import fi.nls.hakunapi.core.DatetimeProperty;
 import fi.nls.hakunapi.core.FeatureType;
+import fi.nls.hakunapi.core.HakunapiPlaceholder;
+import fi.nls.hakunapi.core.HakunapiPlaceholder.PlaceholderSegment;
 import fi.nls.hakunapi.core.SRIDCode;
 import fi.nls.hakunapi.core.SimpleFeatureType;
 import fi.nls.hakunapi.core.SimpleSource;
@@ -77,9 +79,41 @@ public class HakunaConfigParser {
     protected final Properties cfg;
 
     public HakunaConfigParser(Properties cfg) {
-        this.cfg = cfg;
+        this.cfg = replacePlaceholders(cfg);
     }
     
+    private static Properties replacePlaceholders(Properties src) {
+        Properties replaced = new Properties();
+        src.forEach((k, v) -> replaced.put(k, replacePlaceholderValue(v)));
+        return replaced;
+    }
+
+    private static Object replacePlaceholderValue(Object value) {
+        if (value instanceof String) {
+            return HakunapiPlaceholder.parseSegments(((String) value).strip()).stream()
+                    .map(HakunaConfigParser::mapPlaceholderValue)
+                    .collect(Collectors.joining());
+        }
+        return value;
+    }
+
+    private static String mapPlaceholderValue(PlaceholderSegment segment) {
+        String v = segment.value();
+        if (!segment.isPlaceholder()) {
+            return v;
+        }
+        String env = System.getenv(v);
+        if (env != null) {
+            return env;
+        }
+        String prop = System.getProperty(v);
+        if (prop != null) {
+            return prop;
+        }
+        // TODO: add fallback values to PlaceholderSegments?
+        throw new IllegalArgumentException("Could not find value for placeholder " + v);
+    }
+
     public Info readInfo() {
         Info info = new Info();
         info.setTitle(cfg.getProperty("api.title", "hakunapi OGC API Features Server"));

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -110,8 +110,8 @@ public class HakunaConfigParser {
         if (prop != null) {
             return prop;
         }
-        // TODO: add fallback values to PlaceholderSegments?
-        throw new IllegalArgumentException("Could not find value for placeholder " + v);
+        // If we can't replace it at this stage leave it as is
+        return String.format("${%s}", v);
     }
 
     public Info readInfo() {

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -28,7 +28,6 @@ import fi.nls.hakunapi.core.CacheSettings;
 import fi.nls.hakunapi.core.DatetimeProperty;
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.HakunapiPlaceholder;
-import fi.nls.hakunapi.core.HakunapiPlaceholder.PlaceholderSegment;
 import fi.nls.hakunapi.core.SRIDCode;
 import fi.nls.hakunapi.core.SimpleFeatureType;
 import fi.nls.hakunapi.core.SimpleSource;
@@ -79,39 +78,7 @@ public class HakunaConfigParser {
     protected final Properties cfg;
 
     public HakunaConfigParser(Properties cfg) {
-        this.cfg = replacePlaceholders(cfg);
-    }
-    
-    private static Properties replacePlaceholders(Properties src) {
-        Properties replaced = new Properties();
-        src.forEach((k, v) -> replaced.put(k, replacePlaceholderValue(v)));
-        return replaced;
-    }
-
-    private static Object replacePlaceholderValue(Object value) {
-        if (value instanceof String) {
-            return HakunapiPlaceholder.parseSegments(((String) value).strip()).stream()
-                    .map(HakunaConfigParser::mapPlaceholderValue)
-                    .collect(Collectors.joining());
-        }
-        return value;
-    }
-
-    private static String mapPlaceholderValue(PlaceholderSegment segment) {
-        String v = segment.value();
-        if (!segment.isPlaceholder()) {
-            return v;
-        }
-        String env = System.getenv(v);
-        if (env != null) {
-            return env;
-        }
-        String prop = System.getProperty(v);
-        if (prop != null) {
-            return prop;
-        }
-        // If we can't replace it at this stage leave it as is
-        return String.format("${%s}", v);
+        this.cfg = HakunapiPlaceholder.replacePlaceholders(cfg);
     }
 
     public Info readInfo() {

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/config/HakunaConfigParserTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/config/HakunaConfigParserTest.java
@@ -2,9 +2,9 @@ package fi.nls.hakunapi.core.config;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import org.junit.Test;
+import java.util.Properties;
 
-import fi.nls.hakunapi.core.config.HakunaConfigParser;
+import org.junit.Test;
 
 public class HakunaConfigParserTest {
 
@@ -14,6 +14,28 @@ public class HakunaConfigParserTest {
         int[] actuals = HakunaConfigParser.getSRIDs(srid);
         int[] expecteds = { 3067, 4326, 1337 };
         assertArrayEquals(expecteds, actuals);
+    }
+
+    @Test
+    public void testExternalizedProperties() {
+        String property = "hakunapi.test";
+        String initialTestValue = System.getProperty(property);
+
+        System.setProperty(property, "dynamic");
+
+        Properties cfg = new Properties();
+        cfg.setProperty("test.static", "my_static_value");
+        cfg.setProperty("test.dynamic", "my_${hakunapi.test}_value");
+
+        HakunaConfigParser parser = new HakunaConfigParser(cfg);
+        parser.get("my_static_value", "test.static");
+        parser.get("my_dynamic_value", "test.dynamic");
+
+        if (initialTestValue != null) {
+            System.setProperty(property, initialTestValue);
+        } else {
+            System.clearProperty(property);
+        }
     }
 
 }

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/config/HakunaConfigParserTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/config/HakunaConfigParserTest.java
@@ -1,6 +1,7 @@
 package fi.nls.hakunapi.core.config;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
 
@@ -26,10 +27,13 @@ public class HakunaConfigParserTest {
         Properties cfg = new Properties();
         cfg.setProperty("test.static", "my_static_value");
         cfg.setProperty("test.dynamic", "my_${hakunapi.test}_value");
+        cfg.setProperty("servers.dev.url", "https://${X-Forwarded-Host}/${X-Forwarded-Path}");
 
         HakunaConfigParser parser = new HakunaConfigParser(cfg);
-        parser.get("my_static_value", "test.static");
-        parser.get("my_dynamic_value", "test.dynamic");
+
+        assertEquals("my_static_value", parser.get("test.static"));
+        assertEquals("my_dynamic_value", parser.get("test.dynamic"));
+        assertEquals("https://${X-Forwarded-Host}/${X-Forwarded-Path}", parser.get("servers.dev.url"));
 
         if (initialTestValue != null) {
             System.setProperty(property, initialTestValue);

--- a/src/hakunapi-source-postgis/src/test/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSourceTest.java
+++ b/src/hakunapi-source-postgis/src/test/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSourceTest.java
@@ -4,9 +4,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Properties;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import fi.nls.hakunapi.core.config.HakunaConfigParser;
 
 public class PostGISSimpleSourceTest {
 
@@ -21,6 +24,24 @@ public class PostGISSimpleSourceTest {
     public void testRelativePath() {
         Path relative = Paths.get("tilanne.properties");
         assertEquals(Paths.get("foo.properties"), Paths.get(PostGISSimpleSource.getDataSourcePath(relative, "foo")));
+    }
+
+    @Test
+    public void testReadingInlinedDBProperties() {
+        Properties props = new Properties();
+        props.put("db", "my_db");
+        props.put("db.my_db.datasource.url", "localhost");
+        props.put("db.my_db.datasource.port", "5432");
+        props.put("db.my_db.datasource.whatever", "no-you");
+        props.put("db.my_db.whatever", "yeah");
+
+        Properties toPassToHikari = PostGISSimpleSource.getInlinedDBProperties(new HakunaConfigParser(props), "my_db");
+
+        assertEquals(4, toPassToHikari.size());
+        assertEquals("localhost", toPassToHikari.get("datasource.url"));
+        assertEquals("5432", toPassToHikari.get("datasource.port"));
+        assertEquals("no-you", toPassToHikari.get("datasource.whatever"));
+        assertEquals("yeah", toPassToHikari.get("whatever"));
     }
 
 }


### PR DESCRIPTION
Allow placeholders to be used in configuration. The main goal was to allow users to configure database connection settings as environment variables as requested in #50.

HakunapiConfigParser will now try to replace `${<placeholder>}` snippets in property values by checking if an
1) environment variable or a
2) system property with that placeholder name exists.

If the placeholder value can't be resolved it's left as is. This is done because some next step might expect the value remain as a placeholder, for example the server url config added in #63.

Additionally, allow postgis database configurations to be inlined in hakunapi main configuration file, e.g.:
```
db=my_db
db.my_db.dataSourceClassName=org.postgresql.ds.PGSimpleDataSource
db.my_db.dataSource.user=address_reader
db.my_db.dataSource.password=test
db.my_db.dataSource.databaseName=address_fin
db.my_db.dataSource.portNumber=${DB_PORT}
db.my_db.dataSource.serverName=localhost

collections.addresses.db=my_db
```
Everything under `db.<database_identifier>.*` is passed on to HikariCP as-is (as in with the `db.<database_identifier>.` prefix removed). The end result is identical to a separate `<database_identifier>.properties` file.