### PR TITLE
Replace placeholders in external db properties

### DIFF
--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
@@ -1,5 +1,6 @@
 package fi.nls.hakunapi.simple.postgis;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import fi.nls.hakunapi.core.HakunapiPlaceholder;
 import fi.nls.hakunapi.core.PaginationStrategy;
 import fi.nls.hakunapi.core.PaginationStrategyCursor;
 import fi.nls.hakunapi.core.PaginationStrategyOffset;
@@ -135,14 +137,27 @@ public class PostGISSimpleSource implements SimpleSource {
         return prefix + name + ".properties";
     }
 
-    private Properties loadProperties(String path) {
-       try (InputStream in = new FileInputStream(path)) {
-         Properties props = new Properties();
-         props.load(in);
-         return props;
-       } catch (IOException e) {
-          throw new RuntimeException("Failed to read property file", e);
-       }
+    protected Properties loadProperties(String path) {
+        try (InputStream in = getInputStream(path)) {
+            Properties props = new Properties();
+            props.load(in);
+            return HakunapiPlaceholder.replacePlaceholders(props);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read property file", e);
+        }
+    }
+
+    protected InputStream getInputStream(String path) throws IOException {
+        File file = new File(path);
+        if (file.isFile()) {
+            return new FileInputStream(file);
+        }
+        InputStream resource = getClass().getResourceAsStream(path);
+        if (resource != null) {
+            return resource;
+        }
+        resource = getClass().getClassLoader().getResourceAsStream(path);
+        return resource;
     }
 
     @Override

--- a/src/hakunapi-source-postgis/src/test/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSourceTest.java
+++ b/src/hakunapi-source-postgis/src/test/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSourceTest.java
@@ -44,4 +44,24 @@ public class PostGISSimpleSourceTest {
         assertEquals("yeah", toPassToHikari.get("whatever"));
     }
 
+    @Test
+    public void testReadingExternalDBProperties() {
+        String oldMyProp = System.getProperty("my.prop");
+        System.setProperty("my.prop", "yeah");
+
+        PostGISSimpleSource pg = new PostGISSimpleSource();
+        Properties properties = pg.loadProperties("test.properties");
+        assertEquals(4, properties.size());
+        assertEquals("localhost", properties.get("datasource.url"));
+        assertEquals("5432", properties.get("datasource.port"));
+        assertEquals("no-you", properties.get("datasource.whatever"));
+        assertEquals("yeah", properties.get("whatever"));
+
+        if (oldMyProp == null) {
+            System.clearProperty("my.prop");
+        } else {
+            System.setProperty("my.prop", oldMyProp);
+        }
+    }
+
 }

--- a/src/hakunapi-source-postgis/src/test/resources/test.properties
+++ b/src/hakunapi-source-postgis/src/test/resources/test.properties
@@ -1,0 +1,4 @@
+datasource.url=localhost
+datasource.port=5432
+datasource.whatever=no-you
+whatever=${my.prop}


### PR DESCRIPTION
#66 claimed it already implemented this but upon further inspection it turned out 1acefa4cfbfd1787292b1024afe5e3a4f8acf7dc was missing the critical line of actually calling `HakunapiPlaceholder.replacePlaceholders(Properties)`.

The diff is a bit larger as I added resource files as potential locations for such files to ease the pain with unit testing. 