### PR TITLE
Use custom ObjectMapper for /api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
 				<artifactId>swagger-models</artifactId>
 				<version>${swagger.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-core</artifactId>
+				<version>${swagger.version}</version>
+			</dependency>
 
 			<dependency>
 				<groupId>org.locationtech.jts</groupId>

--- a/src/hakunapi-simple-servlet-javax/pom.xml
+++ b/src/hakunapi-simple-servlet-javax/pom.xml
@@ -71,6 +71,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
             <version>2.5.5</version>

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/OpenAPIObjectMapperProvider.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/OpenAPIObjectMapperProvider.java
@@ -1,0 +1,21 @@
+package fi.nls.hakunapi.simple.servlet.javax;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.swagger.v3.core.util.Json;
+
+@Provider
+@Produces("application/vnd.oai.openapi+json;version=3.0")
+public class OpenAPIObjectMapperProvider implements ContextResolver<ObjectMapper> {
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return Json.mapper().enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+}

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
@@ -46,7 +46,7 @@ public class OpenAPI30ApiOperation {
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<OpenAPI> html(@Context HttpHeaders headers) {
         String basePath = service.getCurrentServerURL(headers::getHeaderString);
-        return new HTMLContext<>(service, basePath, api.create(headers));
+        return new HTMLContext<>(service, basePath, new OpenAPI());
     }
     
     @GET
@@ -54,7 +54,7 @@ public class OpenAPI30ApiOperation {
     @Produces(MediaType.TEXT_HTML)
     public HTMLContext<OpenAPI> htmlExt(@Context HttpHeaders headers) {
         String basePath = service.getCurrentServerURL(headers::getHeaderString);
-        return new HTMLContext<>(service, basePath, api.create(headers));
+        return new HTMLContext<>(service, basePath, new OpenAPI());
     }
 
 }

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
@@ -40,6 +40,7 @@ import fi.nls.hakunapi.simple.servlet.javax.GzipFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GzipInterceptor;
 import fi.nls.hakunapi.simple.servlet.javax.NotFoundExceptionMapper;
 import fi.nls.hakunapi.simple.servlet.javax.ObjectMapperProvider;
+import fi.nls.hakunapi.simple.servlet.javax.OpenAPIObjectMapperProvider;
 import fi.nls.hakunapi.simple.servlet.javax.operation.CollectionMetadataImpl;
 import fi.nls.hakunapi.simple.servlet.javax.operation.CollectionsMetadataImpl;
 import fi.nls.hakunapi.simple.servlet.javax.operation.ConformanceImpl;
@@ -119,6 +120,8 @@ public class SimpleFeaturesApplication extends ResourceConfig {
         // Use Jackson as POJO provider
         register(ObjectMapperProvider.class);
         register(JacksonFeature.class);
+
+        register(OpenAPIObjectMapperProvider.class);
 
         OutputFormat html = service.getOutputFormat(OutputFormatHTML.ID);
         if (html != null) {

--- a/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
+++ b/src/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.either;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 
@@ -76,6 +77,7 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 		with(response)
 				//
 				.assertThat("$.openapi", equalTo("3.0.1"));
+		assertFalse(response.contains("exampleSetFlag"));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Linked issue #69 

Use the ObjectMapper provided by `io.swagger.core.v3.swagger-core` module as suggested by the project.

Additionally change the way `/api.html` is generated. Current api.ftl template uses `url: /api.json` to fetch the actual api document with another request. So we can just return a dummy version of `new OpenAPI()` instead and the HTML version still works the same.

