### PR TITLE
Remove "N/A" fallback values from contact information

### DIFF
--- a/examples/finnish_addresses/README.md
+++ b/examples/finnish_addresses/README.md
@@ -97,6 +97,16 @@ Restart your tomcat instance and navigate to http://localhost:8080/features
 
 ## Preparing for production
 
+### Configure contact information
+
+Enable (by removing the #) and provide correct values for the following properties in `addresses.properties`:
+
+```
+#api.contact.name=Name of Contact
+#api.contact.email=concat@email.com
+#api.contact.url=https://github.com/nlsfi/hakunapi
+```
+
 ### Configure endpoint servers
 
 In order for hakunapi to work properly it needs to know the URL the user is using to access it. Currently hakunapi only supports setting this manually in the configuration (meaning there's no support for extracting the information from http headers for example), see `addresses.properties` lines 12-17:

--- a/examples/finnish_addresses/cfg/addresses.properties
+++ b/examples/finnish_addresses/cfg/addresses.properties
@@ -3,9 +3,9 @@
 api.title=INSPIRE Simple Addresses, Finland
 api.version=0.1
 api.description=Example implementation of OGC API Services with hakunapi. INSPIRE Simple Addresses from Finland. Data from 13.02.2023 https://www.avoindata.fi/data/fi/dataset/rakennusten-osoitetiedot-koko-suomi by Finnish Digital and Population Data services Agency.
-api.contact.name=Name of Contact
-api.contact.email=
-api.contact.url=https://github.com/nlsfi/hakunapi
+#api.contact.name=Name of Contact
+#api.contact.email=concat@email.com
+#api.contact.url=https://github.com/nlsfi/hakunapi
 api.license.name=Data accessed from the API is licensed by the Digital and Population Data Services Agency CC BY 4.0 licence.
 api.license.url=https://creativecommons.org/licenses/by/4.0/
 

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -88,10 +88,12 @@ public class HakunaConfigParser {
         info.setDescription(cfg.getProperty("api.description", "hakunapi OGC API Features Server"));
 
         Contact contact = new Contact();
-        contact.setName(cfg.getProperty("api.contact.name", "N/A"));
-        contact.setEmail(cfg.getProperty("api.contact.email", "N/A"));
-        contact.setUrl(cfg.getProperty("api.contact.url", "N/A"));
-        info.setContact(contact);
+        contact.setName(cfg.getProperty("api.contact.name"));
+        contact.setEmail(cfg.getProperty("api.contact.email"));
+        contact.setUrl(cfg.getProperty("api.contact.url"));
+        if (contact.getName() != null || contact.getEmail() != null || contact.getUrl() != null) {
+            info.setContact(contact);
+        }
 
         License license = new License();
         license.setName(cfg.getProperty("api.license.name"));


### PR DESCRIPTION
Related issue #69 

Currently if user omits following properties from configuration:
```
api.contact.name=
api.contact.email=
api.contact.url=
```
hakunapi will use `N/A` as fallback value for each property, which is never valid value for email or url. 

Instead just omit the contact information from the OpenAPI description altogether if none of the properties is set and don't set non-null values for fields that are not configured.

Additionally change the finnish_addresses example to reflect the change.