### PR TITLE
Global f query param blocks f param from items

### DIFF
--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/NotAcceptableExceptionMapper.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/NotAcceptableExceptionMapper.java
@@ -1,0 +1,14 @@
+package fi.nls.hakunapi.simple.servlet.javax;
+
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class NotAcceptableExceptionMapper implements ExceptionMapper<NotAcceptableException> {
+
+    public Response toResponse(NotAcceptableException exception) {
+        return ResponseUtil.exception(Status.NOT_ACCEPTABLE, exception.getMessage());
+    }
+
+}

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
@@ -121,8 +122,11 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
             GetFeaturesUtil.modify(service, request, NON_DYNAMIC, uriInfo.getQueryParameters());
 
             GetCollectionItemsOperation.checkUnknownParameters(service, NON_DYNAMIC, uriInfo.getQueryParameters());
+            GetCollectionItemsOperation.checkUnknownOutputFormat(request);
         } catch (IllegalArgumentException e) {
             return ResponseUtil.exception(Status.BAD_REQUEST, e.getMessage());
+        } catch (NotAcceptableException e) {
+            return ResponseUtil.exception(Status.NOT_ACCEPTABLE, e.getMessage());
         }
         try (SingleFeatureWriter writer = request.getFormat().getSingleFeatureWriter()) {
             return getResponse(writer, ft.getFeatureProducer(), request, c);

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemsOperation.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
@@ -132,6 +133,8 @@ public class GetCollectionItemsOperation implements DynamicPathOperation, Dynami
             }
         } catch (IllegalArgumentException e) {
             return ResponseUtil.exception(Status.BAD_REQUEST, e.getMessage());
+        } catch (NotAcceptableException e) {
+            return ResponseUtil.exception(Status.NOT_ACCEPTABLE, e.getMessage());
         }
 
         GetFeatureCollection c = request.getCollections().get(0);
@@ -203,7 +206,9 @@ public class GetCollectionItemsOperation implements DynamicPathOperation, Dynami
         GetFeaturesUtil.modify(service, request, ParamUtil.getParameters(ft, service), uriInfo.getQueryParameters());
 
         checkUnknownParameters(service, ParamUtil.getParameters(ft, service), uriInfo.getQueryParameters());
-        
+
+        checkUnknownOutputFormat(request);
+
         return request;
     }
     
@@ -247,6 +252,12 @@ public class GetCollectionItemsOperation implements DynamicPathOperation, Dynami
             }
             String err = String.format("Unknown parameter '%s'", key);
             throw new IllegalArgumentException(err);
+        }
+    }
+
+    public static void checkUnknownOutputFormat(GetFeatureRequest request) {
+        if (request.getFormat() == null) {
+            throw new NotAcceptableException();
         }
     }
 

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
+import javax.ws.rs.NotAcceptableException;
 import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
@@ -82,8 +83,12 @@ public class GetItemsOperation implements ParametrizedOperation, DynamicResponse
             request.getCollections().stream()
                     .map(fc -> fc.getFt().getParameters())
                     .forEach(param -> GetFeaturesUtil.modify(service, request, param, queryParams));
+
+            GetCollectionItemsOperation.checkUnknownOutputFormat(request);
         } catch (IllegalArgumentException e) {
             return ResponseUtil.exception(Status.BAD_REQUEST, e.getMessage());
+        } catch (NotAcceptableException e) {
+            return ResponseUtil.exception(Status.NOT_ACCEPTABLE, e.getMessage());
         }
 
         StreamingOutput output = new StreamingOutput() {

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
@@ -90,6 +90,7 @@ public class SimpleFeaturesApplication extends ResourceConfig {
         register(NotFoundExceptionMapper.class);
         register(CatchAllExceptionMapper.class);
 
+        final GlobalFQueryParamFilter fParamFilter = new GlobalFQueryParamFilter(service);
         register(GlobalFQueryParamFilter.class);
 
         if (Boolean.parseBoolean(parser.get("hakuna.cors", "true"))) {
@@ -111,6 +112,7 @@ public class SimpleFeaturesApplication extends ResourceConfig {
                 bind(service).to(FeatureServiceConfig.class);
                 bind(service).to(SimpleFeatureServiceConfig.class);
                 bind(api).to(OpenAPI30ApiOperation.class);
+                bind(fParamFilter).to(GlobalFQueryParamFilter.class);
                 bind(cacheManager).to(CacheManager.class);
             }
         });

--- a/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
+++ b/src/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/SimpleFeaturesApplication.java
@@ -38,6 +38,7 @@ import fi.nls.hakunapi.simple.servlet.javax.CorsFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GlobalFQueryParamFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GzipFilter;
 import fi.nls.hakunapi.simple.servlet.javax.GzipInterceptor;
+import fi.nls.hakunapi.simple.servlet.javax.NotAcceptableExceptionMapper;
 import fi.nls.hakunapi.simple.servlet.javax.NotFoundExceptionMapper;
 import fi.nls.hakunapi.simple.servlet.javax.ObjectMapperProvider;
 import fi.nls.hakunapi.simple.servlet.javax.OpenAPIObjectMapperProvider;
@@ -88,6 +89,7 @@ public class SimpleFeaturesApplication extends ResourceConfig {
         }
 
         register(NotFoundExceptionMapper.class);
+        register(NotAcceptableExceptionMapper.class);
         register(CatchAllExceptionMapper.class);
 
         final GlobalFQueryParamFilter fParamFilter = new GlobalFQueryParamFilter(service);


### PR DESCRIPTION
Allow custom outputformats (e.g. `jsonfg`, `gpkg`) to pass the global query param `f` checks.