### PR TITLE
GeoPackage output format: fix example and geometry bug

### DIFF
--- a/examples/finnish_addresses/README.md
+++ b/examples/finnish_addresses/README.md
@@ -97,6 +97,14 @@ Restart your tomcat instance and navigate to http://localhost:8080/features
 
 ## Preparing for production
 
+### Configure GeoPackage output format
+
+GeoPackage output format requires a directory in which it can create temporary SQLite (geopackage) files before they are ready to be written out to the client. On startup GeoPackage output format factory checks if the configured directory exists and also tests if it can write files to that directory. If any of the checks fail the output format doesn't get loaded. So either create a `tmp` directory in `/app/features_addresses` or adjust the tmp directory path to fit your needs.
+
+```
+formats.gpkg.dir=/app/features_addresses/tmp
+```
+
 ### Configure contact information
 
 Enable (by removing the #) and provide correct values for the following properties in `addresses.properties`:

--- a/examples/finnish_addresses/cfg/addresses.properties
+++ b/examples/finnish_addresses/cfg/addresses.properties
@@ -23,6 +23,7 @@ formats.geojson.type=json
 # formats.geojson.forceLonLat=true
 formats.html.type=html
 formats.gpkg.type=gpkg
+formats.gpkg.dir=/app/features_addresses/tmp
 getfeatures.limit.default=10
 getfeatures.limit.max=10000
 

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/geom/HakunaGeometryEWKB.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/geom/HakunaGeometryEWKB.java
@@ -303,7 +303,7 @@ public class HakunaGeometryEWKB implements HakunaGeometry {
             }
             wkb[off] = ewkb[0];
             putInt(wkb, off + 1, bo, type);
-            System.arraycopy(ewkb, 9, wkb, off + 5, wkb.length - 5);
+            System.arraycopy(ewkb, 9, wkb, off + 5, ewkb.length - 9);
             return;
         }
 


### PR DESCRIPTION
After fixing #81 noticed that the GeoPackage output format still doesn't work with example configuration in simple-addresses, fixed that.

While working on GeoPackage source noticed that `HakunaGeometryEWKB toWKB()` didn't work correctly in some cases, fixed that.