### PR TITLE
force json based outputformats when none specified

### DIFF
--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/GlobalFQueryParamFilter.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/GlobalFQueryParamFilter.java
@@ -29,7 +29,7 @@ public class GlobalFQueryParamFilter implements ContainerRequestFilter {
     
     private static final List<String> DEFAULT_ACCEPT_VALUES = 
             List.of(MediaType.APPLICATION_JSON, MediaTypes.APPLICATION_GEOJSON, 
-                    // "application/schema+json","application/vnd.oai.openapi+json;version=3.0", 
+                    MediaTypes.APPLICATION_SCHEMA, MediaTypes.APPLICATION_OPENAPI_V3,
                     "*/*" );
 
     @Override

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/MediaTypes.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/MediaTypes.java
@@ -1,0 +1,9 @@
+package fi.nls.hakunapi.simple.servlet.javax;
+
+public class MediaTypes {
+
+    public static final String APPLICATION_OPENAPI_V3 = "application/vnd.oai.openapi+json;version=3.0";
+    public static final String APPLICATION_SCHEMA = "application/schema+json";
+    public static final String APPLICATION_GEOJSON = "application/geo+json";
+
+}

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/OpenAPIObjectMapperProvider.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/OpenAPIObjectMapperProvider.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import io.swagger.v3.core.util.Json;
 
 @Provider
-@Produces("application/vnd.oai.openapi+json;version=3.0")
+@Produces(MediaTypes.APPLICATION_OPENAPI_V3)
 public class OpenAPIObjectMapperProvider implements ContextResolver<ObjectMapper> {
 
     @Override

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionQueryablesImpl.java
@@ -16,15 +16,17 @@ import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.property.HakunaProperty;
 import fi.nls.hakunapi.core.schemas.Queryables;
 import fi.nls.hakunapi.html.model.HTMLContext;
+import fi.nls.hakunapi.simple.servlet.javax.MediaTypes;
 
 @Path("/collections/{collectionId}/queryables")
 public class GetCollectionQueryablesImpl {
+
 
     @Inject
     private FeatureServiceConfig service;
 
     @GET
-    @Produces("application/schema+json")
+    @Produces(MediaTypes.APPLICATION_SCHEMA)
     public Queryables handle(
             @PathParam("collectionId") String collectionId,
             @Context UriInfo uriInfo,

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionSchemaImpl.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionSchemaImpl.java
@@ -20,6 +20,7 @@ import fi.nls.hakunapi.core.property.simple.HakunaPropertyGeometry;
 import fi.nls.hakunapi.core.schemas.GeoJSONGeometrySchema;
 import fi.nls.hakunapi.core.schemas.OAS30toJsonSchema;
 import fi.nls.hakunapi.core.schemas.SchemaDefinition;
+import fi.nls.hakunapi.simple.servlet.javax.MediaTypes;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -27,12 +28,14 @@ import io.swagger.v3.oas.models.media.StringSchema;
 @Path("/collections")
 public class GetCollectionSchemaImpl {
 
+    
+    
     @Inject
     private FeatureServiceConfig service;
 
     @GET
     @Path("/{collectionId}/schema")
-    @Produces("application/schema+json")
+    @Produces(MediaTypes.APPLICATION_SCHEMA)
     public SchemaDefinition handle(
             @PathParam("collectionId") String collectionId,
             @Context UriInfo uriInfo,

--- a/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
+++ b/src/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/OpenAPI30ApiOperation.java
@@ -13,12 +13,14 @@ import javax.ws.rs.core.MediaType;
 import fi.nls.hakunapi.core.FeatureServiceConfig;
 import fi.nls.hakunapi.core.operation.OperationImpl;
 import fi.nls.hakunapi.html.model.HTMLContext;
+import fi.nls.hakunapi.simple.servlet.javax.MediaTypes;
 import io.swagger.v3.oas.models.OpenAPI;
 
 @Singleton
 @Path("/")
 public class OpenAPI30ApiOperation {
 
+    
     private final FeatureServiceConfig service;
     private final OpenAPI30Generator api;
 
@@ -29,14 +31,14 @@ public class OpenAPI30ApiOperation {
 
     @GET
     @Path("/api")
-    @Produces("application/vnd.oai.openapi+json;version=3.0")
+    @Produces(MediaTypes.APPLICATION_OPENAPI_V3)
     public OpenAPI json(@Context HttpHeaders headers) {
         return api.create(headers);
     }
 
     @GET
     @Path("/api.json")
-    @Produces("application/vnd.oai.openapi+json;version=3.0")
+    @Produces(MediaTypes.APPLICATION_OPENAPI_V3)
     public OpenAPI jsonExt(@Context HttpHeaders headers) {
         return api.create(headers);
     }


### PR DESCRIPTION
Force json based outputformats when none specified in request f parameter or accept header

There is some randomness in Jersey request matching when request has not specified any output format - sometimes html and other times json responses.

Added force to GlobalFQueryFilter with a supporting class MediaTypes with some constants for output formats.

Other approach would be to include qs q-values : 
https://jakarta.ee/specifications/restful-ws/3.1/jakarta-restful-ws-spec-3.1.html#selecting_from_multiple_media_types

