### PR TITLE
Support multiple floating point formatter configurations for JSONFG geometry and place output - with side effects

### DIFF
--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryWriter.java
@@ -2,6 +2,7 @@ package fi.nls.hakunapi.geojson.hakuna;
 
 import java.io.IOException;
 
+import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.GeometryWriter;
 import fi.nls.hakunapi.core.geom.HakunaGeometryType;
 
@@ -10,11 +11,13 @@ public class HakunaGeoJSONGeometryWriter implements GeometryWriter {
     protected final HakunaJsonWriter json;
     protected final byte[] fieldName;
     protected final boolean lonLat;
+    protected FloatingPointFormatter formatter;
 
-    public HakunaGeoJSONGeometryWriter(HakunaJsonWriter json, byte[] fieldName, boolean lonLat) {
+    public HakunaGeoJSONGeometryWriter(HakunaJsonWriter json, FloatingPointFormatter f, byte[] fieldName, boolean lonLat) {
         this.json = json;
         this.fieldName = fieldName;
         this.lonLat = lonLat;
+        this.formatter = f;
     }
 
     @Override
@@ -46,25 +49,25 @@ public class HakunaGeoJSONGeometryWriter implements GeometryWriter {
 
     public void writeCoordinate(double x, double y) throws IOException {
         if (lonLat) {
-            json.writeCoordinate(x, y);
+            json.writeCoordinate(x, y, formatter);
         } else {
-            json.writeCoordinate(y, x);
+            json.writeCoordinate(y, x, formatter);
         }
     }
 
     public void writeCoordinate(double x, double y, double z) throws IOException {
         if (lonLat) {
-            json.writeCoordinate(x, y, z);
+            json.writeCoordinate(x, y, z, formatter);
         } else {
-            json.writeCoordinate(y, x, z);
+            json.writeCoordinate(y, x, z, formatter);
         }
     }
 
     public void writeCoordinate(double x, double y, double z, double m) throws IOException {
         if (lonLat) {
-            json.writeCoordinate(x, y, z, m);
+            json.writeCoordinate(x, y, z, m, formatter);
         } else {
-            json.writeCoordinate(y, x, z, m);
+            json.writeCoordinate(y, x, z, m, formatter);
         }
     }
 

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONGeometryXYZMWriter.java
@@ -2,16 +2,17 @@ package fi.nls.hakunapi.geojson.hakuna;
 
 import java.io.IOException;
 
+import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 
 public class HakunaGeoJSONGeometryXYZMWriter extends HakunaGeoJSONGeometryWriter {
 
     private final HakunaGeometryDimension mode;
 
-    public HakunaGeoJSONGeometryXYZMWriter(HakunaJsonWriter json, byte[] fieldName,
+    public HakunaGeoJSONGeometryXYZMWriter(HakunaJsonWriter json, FloatingPointFormatter formatter, byte[] fieldName,
             boolean lonLat,
             HakunaGeometryDimension mode) {
-        super(json, fieldName, lonLat);
+        super(json, formatter, fieldName, lonLat);
         this.mode = mode;
     }
 

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaGeoJSONWriter.java
@@ -46,6 +46,8 @@ public abstract class HakunaGeoJSONWriter implements FeatureWriter {
 
     protected HakunaGeometryDimension dims;
     protected GeometryWriter geometryJson;
+    protected FloatingPointFormatter decimalFormatter;
+    
     protected Map<String, byte[]> propertyNameUTF8Cache = new HashMap<>();
     protected Map<String, GeometryWriter> propertyGeometryJson = new HashMap<>();
 
@@ -79,6 +81,7 @@ public abstract class HakunaGeoJSONWriter implements FeatureWriter {
         this.srid = srid;
         this.json = new HakunaJsonWriter(out, formatter);
         this.crsIsLatLon = crsIsLatLon;
+        this.decimalFormatter = formatter;
         initGeometryWriter(HakunaGeometryDimension.DEFAULT);
     }
 
@@ -92,14 +95,14 @@ public abstract class HakunaGeoJSONWriter implements FeatureWriter {
     public GeometryWriter geometryWriter(byte[] name, boolean lonLat) {
         switch (dims) {
         case GEOMETRY:
-            return new HakunaGeoJSONGeometryWriter(json, name, lonLat);
+            return new HakunaGeoJSONGeometryWriter(json, decimalFormatter, name, lonLat);
         case EPSG:
         case XY:
         case XYZ:
         case XYZM:
         case DEFAULT:
         default:
-            return new HakunaGeoJSONGeometryXYZMWriter(json, name, lonLat, dims);
+            return new HakunaGeoJSONGeometryXYZMWriter(json, decimalFormatter, name, lonLat, dims);
         }
     }
 

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaJsonWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaJsonWriter.java
@@ -393,6 +393,9 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
         }
     }
 
+    public void writeCoordinate(double x, double y) throws IOException {
+        writeCoordinate(x, y, numberPropertyFormatter);
+    }
     public void writeCoordinate(double x, double y, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ]
         if (pos + 2 + 22 + 1 + 22 + 1 +  2 * f.maxDecimalsOrdinate() >= BUF_LEN) {
@@ -410,6 +413,9 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
         state = (int) (stack & 1L);
     }
 
+    public void writeCoordinate(double x, double y, double z) throws IOException {
+        writeCoordinate( x, y, z, numberPropertyFormatter);
+    }
     public void writeCoordinate(double x, double y, double z, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ,    z]
         if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 3 * f.maxDecimalsOrdinate() >= BUF_LEN) {
@@ -429,6 +435,9 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
         state = (int) (stack & 1L);
     }
 
+    public void writeCoordinate(double x, double y, double z, double m) throws IOException {
+        writeCoordinate(x, y, z, m, numberPropertyFormatter);
+    }
     public void writeCoordinate(double x, double y, double z, double m, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ,    z   ,    m]
         if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 1 + 22 + 4 * f.maxDecimalsOrdinate() >= BUF_LEN) {

--- a/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaJsonWriter.java
+++ b/src/hakunapi-geojson/src/main/java/fi/nls/hakunapi/geojson/hakuna/HakunaJsonWriter.java
@@ -42,7 +42,7 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
     private static final int STATE_INIT = 3;
 
     private final OutputStream out;
-    private final FloatingPointFormatter formatter;
+    private final FloatingPointFormatter numberPropertyFormatter;
 
     private final byte[] buf;
     private int pos;
@@ -53,7 +53,7 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
 
     public HakunaJsonWriter(OutputStream out, FloatingPointFormatter formatter) {
         this.out = out;
-        this.formatter = formatter;
+        this.numberPropertyFormatter = formatter;
         this.buf = new byte[BUF_LEN];
         this.pos = 0;
         this.state = STATE_INIT;
@@ -358,10 +358,10 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
             }
         case STATE_OBJ_VALUE:
             // max char length for long (21) + dot (1) + maxDecimals
-            if (pos + 22 + formatter.maxDecimalsFloat() >= BUF_LEN) {
+            if (pos + 22 + numberPropertyFormatter.maxDecimalsFloat() >= BUF_LEN) {
                 flush();
             }
-            pos = formatter.writeFloat(v, buf, pos);
+            pos = numberPropertyFormatter.writeFloat(v, buf, pos);
             comma = true;
             state >>>= 1; // STATE_ARRAY => STATE_ARRAY, STATE_OBJ_VALUE => STATE_OBJ_KEY
             break;
@@ -381,10 +381,10 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
             }
         case STATE_OBJ_VALUE:
             // max char length for long (21) + dot (1) + maxDecimals
-            if (pos + 22 + formatter.maxDecimalsDouble() >= BUF_LEN) {
+            if (pos + 22 + numberPropertyFormatter.maxDecimalsDouble() >= BUF_LEN) {
                 flush();
             }
-            pos = formatter.writeDouble(v, buf, pos);
+            pos = numberPropertyFormatter.writeDouble(v, buf, pos);
             comma = true;
             state >>>= 1; // STATE_ARRAY => STATE_ARRAY, STATE_OBJ_VALUE => STATE_OBJ_KEY
             break;
@@ -393,58 +393,58 @@ public class HakunaJsonWriter implements AutoCloseable, Flushable {
         }
     }
 
-    public void writeCoordinate(double x, double y) throws IOException {
+    public void writeCoordinate(double x, double y, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ]
-        if (pos + 2 + 22 + 1 + 22 + 1 +  2 * formatter.maxDecimalsOrdinate() >= BUF_LEN) {
+        if (pos + 2 + 22 + 1 + 22 + 1 +  2 * f.maxDecimalsOrdinate() >= BUF_LEN) {
             flush();
         }
         if (comma && state == STATE_ARRAY) {
             buf[pos++] = COMMA;
         }
         buf[pos++] = START_ARR;
-        pos = formatter.writeOrdinate(x, buf, pos);
+        pos = f.writeOrdinate(x, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(y, buf, pos);
+        pos = f.writeOrdinate(y, buf, pos);
         buf[pos++] = END_ARR;
         comma = true;
         state = (int) (stack & 1L);
     }
 
-    public void writeCoordinate(double x, double y, double z) throws IOException {
+    public void writeCoordinate(double x, double y, double z, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ,    z]
-        if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 3 * formatter.maxDecimalsOrdinate() >= BUF_LEN) {
+        if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 3 * f.maxDecimalsOrdinate() >= BUF_LEN) {
             flush();
         }
         if (comma && state == STATE_ARRAY) {
             buf[pos++] = COMMA;
         }
         buf[pos++] = START_ARR;
-        pos = formatter.writeOrdinate(x, buf, pos);
+        pos = f.writeOrdinate(x, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(y, buf, pos);
+        pos = f.writeOrdinate(y, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(z, buf, pos);
+        pos = f.writeOrdinate(z, buf, pos);
         buf[pos++] = END_ARR;
         comma = true;
         state = (int) (stack & 1L);
     }
 
-    public void writeCoordinate(double x, double y, double z, double m) throws IOException {
+    public void writeCoordinate(double x, double y, double z, double m, FloatingPointFormatter f) throws IOException {
         //       ,[    x   ,    y   ,    z   ,    m]
-        if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 1 + 22 + 4 * formatter.maxDecimalsOrdinate() >= BUF_LEN) {
+        if (pos + 2 + 22 + 1 + 22 + 1 + 22 + 1 + 22 + 4 * f.maxDecimalsOrdinate() >= BUF_LEN) {
             flush();
         }
         if (comma && state == STATE_ARRAY) {
             buf[pos++] = COMMA;
         }
         buf[pos++] = START_ARR;
-        pos = formatter.writeOrdinate(x, buf, pos);
+        pos = f.writeOrdinate(x, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(y, buf, pos);
+        pos = f.writeOrdinate(y, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(z, buf, pos);
+        pos = f.writeOrdinate(z, buf, pos);
         buf[pos++] = COMMA;
-        pos = formatter.writeOrdinate(m, buf, pos);
+        pos = numberPropertyFormatter.writeOrdinate(m, buf, pos);
         buf[pos++] = END_ARR;
         comma = true;
         state = (int) (stack & 1L);

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureWriterBase.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureWriterBase.java
@@ -60,7 +60,7 @@ public abstract class HTMLFeatureWriterBase implements FeatureWriter {
         this.formatter = formatter;
         this.geojsonBuffer = new ByteArrayOutputStream();
         this.jsonWriter = new HakunaJsonWriter(geojsonBuffer, formatter);
-        this.geometryWriter = new HakunaGeoJSONGeometryWriterNoField(jsonWriter);
+        this.geometryWriter = new HakunaGeoJSONGeometryWriterNoField(jsonWriter, formatter);
     }
 
     @Override

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HakunaGeoJSONGeometryWriterNoField.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HakunaGeoJSONGeometryWriterNoField.java
@@ -2,23 +2,24 @@ package fi.nls.hakunapi.html.model;
 
 import java.io.IOException;
 
+import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSONGeometryWriter;
 import fi.nls.hakunapi.geojson.hakuna.HakunaJsonWriter;
 
 public class HakunaGeoJSONGeometryWriterNoField extends HakunaGeoJSONGeometryWriter {
 
-    public HakunaGeoJSONGeometryWriterNoField(HakunaJsonWriter json) {
-        super(json, null, true);
+    public HakunaGeoJSONGeometryWriterNoField(HakunaJsonWriter json, FloatingPointFormatter formatter) {
+        super(json, formatter, null, true);
     }
 
     @Override
     public void writeCoordinate(double x, double y, double z) throws IOException {
-        json.writeCoordinate(x, y);
+        json.writeCoordinate(x, y, formatter);
     }
 
     @Override
     public void writeCoordinate(double x, double y, double z, double m) throws IOException {
-        json.writeCoordinate(x, y);
+        json.writeCoordinate(x, y, formatter);
     }
 
 }

--- a/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGGeometryWriter.java
+++ b/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGGeometryWriter.java
@@ -2,6 +2,7 @@ package fi.nls.hakunapi.jsonfg;
 
 import java.io.IOException;
 
+import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 import fi.nls.hakunapi.core.geom.HakunaGeometryType;
 import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSONGeometryWriter;
@@ -10,10 +11,10 @@ import fi.nls.hakunapi.geojson.hakuna.HakunaJsonWriter;
 public class JSONFGGeometryWriter extends HakunaGeoJSONGeometryWriter {
 
     int srid;
-    private HakunaGeometryDimension mode;
+    protected HakunaGeometryDimension mode;
 
-    public JSONFGGeometryWriter(HakunaJsonWriter json, byte[] fieldName, boolean lonLat, HakunaGeometryDimension mode) {
-        super(json, fieldName, lonLat);
+    public JSONFGGeometryWriter(HakunaJsonWriter json, FloatingPointFormatter formatter, byte[] fieldName, boolean lonLat, HakunaGeometryDimension mode) {
+        super(json, formatter, fieldName, lonLat);
         this.mode = mode;
     }
 
@@ -58,4 +59,5 @@ public class JSONFGGeometryWriter extends HakunaGeoJSONGeometryWriter {
             break;
         }
     }
+
 }

--- a/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriter.java
+++ b/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriter.java
@@ -1,16 +1,17 @@
 package fi.nls.hakunapi.jsonfg;
 
+import static fi.nls.hakunapi.core.schemas.Crs.CRS84_SRID;
+import static fi.nls.hakunapi.jsonfg.JSONFG.CRS84_DIM;
+
 import java.time.Instant;
 import java.time.LocalDate;
 
-import static fi.nls.hakunapi.core.schemas.Crs.CRS84_SRID;
 import fi.nls.hakunapi.core.DatetimeProperty;
 import fi.nls.hakunapi.core.FeatureType;
+import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.geom.HakunaGeometry;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 import fi.nls.hakunapi.core.projection.ProjectionTransformer;
-import fi.nls.hakunapi.core.property.simple.HakunaPropertyGeometry;
-import fi.nls.hakunapi.core.util.CrsUtil;
 import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSON;
 import fi.nls.hakunapi.geojson.hakuna.HakunaGeoJSONSingleFeatureWriter;
 
@@ -28,23 +29,25 @@ public class JSONFGSingleFeatureWriter extends HakunaGeoJSONSingleFeatureWriter 
     private Instant timestamp;
     private LocalDate date;
 
+  
     @Override
     public void initGeometryWriter(HakunaGeometryDimension dims) {
         this.dims = dims;
-        geometryJson = new JSONFGGeometryWriter(json, HakunaGeoJSON.GEOMETRY, forceLonLat || !crsIsLatLon, dims);
-        placeJson = new JSONFGGeometryWriter(json, JSONFG.PLACE, forceLonLat || !crsIsLatLon, dims);
+
+        FloatingPointFormatter fCrs84 = JSONFG.createCrs84GeometryFormatter();
+
+        geometryJson = new JSONFGGeometryWriter(json, fCrs84, HakunaGeoJSON.GEOMETRY, true, CRS84_DIM);
+        placeJson = new JSONFGGeometryWriter(json,  decimalFormatter, JSONFG.PLACE, forceLonLat || !crsIsLatLon, CRS84_DIM);
         propertyGeometryJson.clear();
     }
 
     protected void startJsonFgFeature(FeatureType ft) throws Exception {
 
         collectionFt = ft;
-
         if (ft.getDatetimeProperties() != null && !ft.getDatetimeProperties().isEmpty()) {
             dateTimeProperty = ft.getDatetimeProperties().get(0);
             dateTimePropertyName = dateTimeProperty.getProperty().getName();
         }
-
         if (getSrid() == CRS84_SRID) {
             outputCrs84Proj = null;
             isCrs84 = true;
@@ -53,37 +56,9 @@ public class JSONFGSingleFeatureWriter extends HakunaGeoJSONSingleFeatureWriter 
             isCrs84 = outputCrs84Proj.isNOP();
         }
 
-        String ftName = ft.getName();
-        String ftJSONFGSchema = JSONFG.getJSONFGSchema(ft);
-
-        HakunaPropertyGeometry geomType = ft.getGeom();
-        Integer geometryDimension = JSONFG.getGeometryDimension(geomType);
-
-        json.writeStartObject();
-
-        // conformsTo
-        json.writeFieldName(JSONFG.CONFORMS_TO);
-        json.writeStartArray();
-        for (byte[] conf : JSONFG.CONF) {
-            json.writeStringUnsafe(conf);
-        }
-        json.writeEndArray();
-
-        json.writeStringField(JSONFG.FEATURE_TYPE, ftName);
-
-        if (geometryDimension != null) {
-            json.writeFieldName(JSONFG.GEOMETRY_DIMENSION);
-            json.writeNumber(geometryDimension);
-        }
-        if (ftJSONFGSchema != null) {
-            json.writeStringField(JSONFG.FEATURE_SCHEMA, ftJSONFGSchema);
-        }
-
-        if (!isCrs84) {
-            String coordRefSys = CrsUtil.toUri(getSrid());
-            json.writeStringField(JSONFG.COORD_REF_SYS, coordRefSys);
-        }
-
+       
+        JSONFG.writeMetadata(json, ft, getSrid(), isCrs84);
+        
         json.writeFieldName(HakunaGeoJSON.TYPE);
         json.writeStringUnsafe(HakunaGeoJSON.FEATURE, 0, HakunaGeoJSON.FEATURE.length);
         json.writeFieldName(HakunaGeoJSON.ID);

--- a/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriterTest.java
+++ b/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriterTest.java
@@ -16,6 +16,7 @@ import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 import fi.nls.hakunapi.core.request.GetFeatureCollection;
 import fi.nls.hakunapi.core.request.GetFeatureRequest;
+import fi.nls.hakunapi.core.util.CrsUtil;
 import fi.nls.hakunapi.core.util.DefaultFloatingPointFormatter;
 
 public class JSONFGFeatureCollectionWriterTest {
@@ -27,7 +28,6 @@ public class JSONFGFeatureCollectionWriterTest {
 
         FeatureType ft = data.getFeatureTypeWithDate(ftName);
 
-        FloatingPointFormatter f = new DefaultFloatingPointFormatter(0, 5, 0, 5, 0, 13);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         GetFeatureRequest request = new GetFeatureRequest();
@@ -37,7 +37,10 @@ public class JSONFGFeatureCollectionWriterTest {
         try (FeatureStream fs = data.getFeaturesWithDate();
                 FeatureCollectionWriter fw = new JSONFGFeatureCollectionWriter()) {
 
-            fw.init(baos, f, data.PLACE_SRID);
+            int srid =data.PLACE_SRID;
+            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+
+            fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
 
             fw.startFeatureCollection(ft, null);
@@ -51,6 +54,8 @@ public class JSONFGFeatureCollectionWriterTest {
         ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(SerializationFeature.CLOSE_CLOSEABLE);
 
+        System.out.println(new String(baos.toByteArray()));
+        
         JsonNode json = mapper.readTree(baos.toByteArray());
 
         mapper.writeValue(System.out, json);
@@ -66,7 +71,6 @@ public class JSONFGFeatureCollectionWriterTest {
 
         FeatureType ft = data.getFeatureTypeWithTimestamp(ftName);
 
-        FloatingPointFormatter f = new DefaultFloatingPointFormatter(0, 5, 0, 5, 0, 13);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         GetFeatureRequest request = new GetFeatureRequest();
@@ -76,7 +80,10 @@ public class JSONFGFeatureCollectionWriterTest {
         try (FeatureStream fs = data.getFeaturesWithTimestamp();
                 FeatureCollectionWriter fw = new JSONFGFeatureCollectionWriter()) {
 
-            fw.init(baos, f, data.PLACE_SRID);
+            int srid =data.PLACE_SRID;
+            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+
+            fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
 
             fw.startFeatureCollection(ft, null);

--- a/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriterTest.java
+++ b/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriterTest.java
@@ -11,13 +11,12 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 import fi.nls.hakunapi.core.FeatureStream;
 import fi.nls.hakunapi.core.FeatureType;
-import fi.nls.hakunapi.core.FloatingPointFormatter;
 import fi.nls.hakunapi.core.ValueProvider;
 import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 import fi.nls.hakunapi.core.property.HakunaProperty;
 import fi.nls.hakunapi.core.request.GetFeatureCollection;
 import fi.nls.hakunapi.core.request.GetFeatureRequest;
-import fi.nls.hakunapi.core.util.DefaultFloatingPointFormatter;
+import fi.nls.hakunapi.core.util.CrsUtil;
 
 public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
 
@@ -28,7 +27,6 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
 
         FeatureType ft = data.getFeatureTypeWithDate(ftName);
 
-        FloatingPointFormatter f = new DefaultFloatingPointFormatter(0, 5, 0, 5, 0, 13);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         GetFeatureRequest request = new GetFeatureRequest();
@@ -40,7 +38,10 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
 
             ValueProvider feat = fs.next();
 
-            fw.init(baos, f, data.PLACE_SRID);
+            int srid =data.PLACE_SRID;
+            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+
+            fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
 
             // Note: contains implicit call to startFeature !
@@ -75,8 +76,7 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
 
         FeatureType ft = data.getFeatureTypeWithTimestamp(ftName);
 
-        FloatingPointFormatter f = new DefaultFloatingPointFormatter(0, 5, 0, 5, 0, 13);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
         GetFeatureRequest request = new GetFeatureRequest();
         GetFeatureCollection coll = new GetFeatureCollection(ft);
@@ -87,7 +87,10 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
 
             ValueProvider feat = fs.next();
 
-            fw.init(baos, f, data.PLACE_SRID);
+            int srid =data.PLACE_SRID;
+            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+
+            fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
 
             // Note: contains implicit call to startFeature !

--- a/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGTestUtils.java
+++ b/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGTestUtils.java
@@ -51,13 +51,14 @@ public class JSONFGTestUtils {
 
     protected final int SRID = Crs.CRS84_SRID;
     protected final int PLACE_SRID = 3067;
+    protected final boolean PLACE_SRID_IS_LATLON = false;
 
     static final GeometryFactory geomFac = new GeometryFactory();
     static final GeoToolsProjectionTransformerFactory projFac = new GeoToolsProjectionTransformerFactory();
 
     protected static final List<HakunaGeometry> GEOMS = Arrays.asList(
-            new HakunaGeometryJTS(geomFac.createPoint(new Coordinate(385511, 6675311))),
-            new HakunaGeometryJTS(geomFac.createPoint(new Coordinate(385022, 6674022))));
+            new HakunaGeometryJTS(geomFac.createPoint(new Coordinate(385511.123, 6675311.111))),
+            new HakunaGeometryJTS(geomFac.createPoint(new Coordinate(385022.231, 6674022.222))));
 
     final HakunaPropertyGeometry geomProp = new HakunaPropertyGeometry("geometry", "table", "geometry", true,
             HakunaGeometryType.POINT, new int[] { SRID }, PLACE_SRID, 2,


### PR DESCRIPTION
Fixes #26 geometry bugs

Some side effects when fixing JSONFG geometry outputs (see #26 ) :
- Had to make changes to hakunapi-geojson module to fix JSONFG multiple crs, axis-order and decimals geometry output

Backward compatibility 
- Changes to GeoJSON module would be a breaking change for any derived work 
- Fixed with methods for backward compatibility - but I think those are a bad idea in the long run

Changes to GeoJSON module
- adds option to support multiple floating point formatter configurations for coordinates in HakunaJsonWriter and HakunaGeoJSONGeometryWriter
- adds option to use a separate floating point formatter for number properties ( relates to #84 ) in HakunaJsonWriter

Changes to JSONFG module
- support geometry, place output with different crs, floating point formatter options, axis order
- reduce code duplication in JSONFG output format writers
