### PR TITLE
Update TracingServiceTelemetry.java - remove faulty doc return annotation

### DIFF
--- a/src/hakunapi-telemetry-opentelemetry/src/main/java/fi/nls/hakunapi/telemetry/TracingServiceTelemetry.java
+++ b/src/hakunapi-telemetry-opentelemetry/src/main/java/fi/nls/hakunapi/telemetry/TracingServiceTelemetry.java
@@ -116,8 +116,6 @@ public class TracingServiceTelemetry implements ServiceTelemetry {
     /**
      * Initializes an OpenTelemetry SDK with a logging exporter and a
      * SimpleSpanProcessor.
-     *
-     * @return A ready-to-use {@link OpenTelemetry} instance.
      */
     public void initOpenTelemetry(long exportInterval) {
         // Create an instance of PeriodicMetricReader and configure it


### PR DESCRIPTION
fixes error: invalid use of @return Error:       * @return A ready-to-use {@link OpenTelemetry} instance.