### PR TITLE
Support for OGC API Features Part 3 and CQL2 1.0.0

### DIFF
--- a/examples/finnish_addresses/cfg/addresses.properties
+++ b/examples/finnish_addresses/cfg/addresses.properties
@@ -40,9 +40,9 @@ collections=addresses
 collections.addresses.title=Simple Addresses
 collections.addresses.description=Addresses of Finlands Buildings
 
-# Select a strategy for case-insensitive comparisons
-# Valid values can be found from CaseInsensitiveStrategy enum (default value is `lower`)
-# If we indexed an expression `upper(thoroughfare_name)` then it would to configure this to `upper`
+## Select a strategy for case-insensitive comparisons
+## Valid values can be found from CaseInsensitiveStrategy enum (default value is `lower`)
+## If we indexed an expression `upper(thoroughfare_name)` then it would make sense to configure this to `upper`
 collections.addresses.casei=lower
 
 ## Should properties with null values be omitted from the response

--- a/examples/finnish_addresses/cfg/addresses.properties
+++ b/examples/finnish_addresses/cfg/addresses.properties
@@ -40,6 +40,11 @@ collections=addresses
 collections.addresses.title=Simple Addresses
 collections.addresses.description=Addresses of Finlands Buildings
 
+# Select a strategy for case-insensitive comparisons
+# Valid values can be found from CaseInsensitiveStrategy enum (default value is `lower`)
+# If we indexed an expression `upper(thoroughfare_name)` then it would to configure this to `upper`
+collections.addresses.casei=lower
+
 ## Should properties with null values be omitted from the response
 collections.addresses.writeNulls=true
 

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CaseInsensitiveStrategy.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/CaseInsensitiveStrategy.java
@@ -1,0 +1,7 @@
+package fi.nls.hakunapi.core;
+
+public enum CaseInsensitiveStrategy {
+
+    LOWER, UPPER;
+
+}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/ConformanceClass.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/ConformanceClass.java
@@ -25,24 +25,22 @@ public enum ConformanceClass {
     FILTER("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter"),
     FEATURES_FILTER("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"),
     
-    TEMPORAL_OPERATORS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/temporal-operators"),
-    ARRAY_OPERATORS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/array-operators"),
-    PROPERTY_PROPERTY_COMPARISONS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/property-property"),
-    CUSTOM_FUNCTIONS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/functions"),
-    ARITHMETIC_EXPRESSIONS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/arithmetic"),
-    
     // Common Query Language CQL 2
-    BASIC_CQL("http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2"),
+    CQL2_TEXT("http://www.opengis.net/spec/cql2/1.0/conf/cql2-text"),
+    CQL2_JSON("http://www.opengis.net/spec/cql2/1.0/conf/cql2-json"),
+    BASIC_CQL2("http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2"),
     ADVANCED_COMPARISON_OPERATORS("http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators"),
-    BASIC_SPATIAL_OPERATORS("http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-operators"),
-    SPATIAL_OPERATORS("http://www.opengis.net/spec/cql2/1.0/conf/spatial-operators"),
-    FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/functions"),
-    CQL2_TEXT_ENCODING("http://www.opengis.net/spec/cql2/1.0/conf/cql2-text"),
     CASE_INSENSITIVE_COMPARISON("http://www.opengis.net/spec/cql2/1.0/conf/case-insensitive-comparison"),
+    ACCENT_INSENSITIVE_COMPARISON("http://www.opengis.net/spec/cql2/1.0/conf/accent-insensitive-comparison"),
+    BASIC_SPATIAL_FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions"),
+    BAISC_SPATIAL_FUNCTIONS_PLUS("http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions-plus"),
+    SPATIAL_FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/spatial-functions"),
+    TEMPORAL_FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/temporal-functions"),
+    ARRAY_FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/array-functions"),
+    PROPERTY_PROPERTY("http://www.opengis.net/spec/cql2/1.0/conf/property-property"),
+    FUNCTIONS("http://www.opengis.net/spec/cql2/1.0/conf/functions"),
+    ARITHMETIC("http://www.opengis.net/spec/cql2/1.0/conf/arithmetic"),
 
- // ? https://confluence.nls.fi/pages/viewpage.action?pageId=117770040 punaisella conflussa?
-    CQL2_JSON_ENCODING("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/cql2-json"),
-    
     ;
 	
 	

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/ConformanceClass.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/ConformanceClass.java
@@ -20,6 +20,8 @@ public enum ConformanceClass {
     CRS("http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs"),
 
     //OGC API - Features - Part 3: Filtering 
+    QUERYABLES("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables"),
+    QUERYABLES_QUERY_PARAMETERS("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters"),
     FILTER("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter"),
     FEATURES_FILTER("http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"),
     

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/filter/LikeFilter.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/filter/LikeFilter.java
@@ -10,10 +10,9 @@ public class LikeFilter extends Filter {
     private final char wildCard;
     private final char singleChar;
     private final char escape;
-    private final boolean caseInsensitive;
 
     protected LikeFilter(FilterOp like, HakunaProperty prop, Object value, char wildCard, char singleChar, char escape, boolean caseInsensitive) {
-        super(FilterOp.LIKE, prop, Objects.requireNonNull(value));
+        super(FilterOp.LIKE, prop, Objects.requireNonNull(value), caseInsensitive);
         if (prop.getType() != HakunaPropertyType.STRING) {
             throw new IllegalArgumentException("LikeFilter is limited to strings");
         }
@@ -23,7 +22,6 @@ public class LikeFilter extends Filter {
         if (wildCard == singleChar || wildCard == escape || singleChar == escape) {
             throw new IllegalArgumentException("Wildcard char, single char and escape char must be distinguishable from each other");
         }
-        this.caseInsensitive = caseInsensitive;
     }
     
     public char getWildCard() {
@@ -38,10 +36,6 @@ public class LikeFilter extends Filter {
         return escape;
     }
 
-    public boolean isCaseInsensitive() {
-        return caseInsensitive;
-    }
-    
     @Override
     public boolean equals(Object obj) {
         if (!super.equals(obj)) {
@@ -50,8 +44,7 @@ public class LikeFilter extends Filter {
         LikeFilter o = (LikeFilter) obj;
         return wildCard == o.wildCard
                 && singleChar == o.singleChar
-                && escape == o.escape
-                && caseInsensitive == o.caseInsensitive;
+                && escape == o.escape;
     }
     
 }

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/param/FilterCrsParam.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/param/FilterCrsParam.java
@@ -21,6 +21,8 @@ public class FilterCrsParam implements GetFeatureParam {
 
     @Override
     public Parameter toParameter(FeatureServiceConfig service) {
+        // Recommendation 3:
+        // The server SHOULD list the supported coordinate reference system URIs as enums in the schema of the filter-crs parameter
         return new QueryParameter()
                 .name(getParamName())
                 .style(StyleEnum.FORM)

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/property/HakunaPropertyComposite.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/property/HakunaPropertyComposite.java
@@ -56,6 +56,10 @@ public class HakunaPropertyComposite extends HakunaPropertyBase {
     }
 
     public Filter toFilter(FilterOp op, String s) {
+        return toFilter(op, s, false);
+    }
+
+    public Filter toFilter(FilterOp op, String s, boolean caseInsensitive) {
         Object[] values = (Object[]) transformer.toInner(s);
         if (values == null) {
             return Filter.DENY;
@@ -69,7 +73,7 @@ public class HakunaPropertyComposite extends HakunaPropertyBase {
                     return Filter.DENY;
                 }
             } else {
-                and.add(new Filter(op, prop, value));
+                and.add(new Filter(op, prop, value, caseInsensitive));
             }
         }
         return Filter.and(and);

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/schemas/Queryables.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/schemas/Queryables.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.models.media.Schema;
 @JsonPropertyOrder({ "$schema", "$id", "title", "description", "type", "properties" })
 public class Queryables implements Component {
 
-    private final String schema = "https://json-schema.org/draft/2019-09/schema";
+    private final String schema = "https://json-schema.org/draft/2020-12/schema";
     private final String id;
     private final String title;
     private final String description;

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/schemas/SchemaDefinition.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/schemas/SchemaDefinition.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.models.media.Schema;
 @JsonPropertyOrder({ "$schema", "$id", "title", "description", "type", "properties" })
 public class SchemaDefinition implements Component {
 
-    private final String schema = "https://json-schema.org/draft/2019-09/schema";
+    private final String schema = "https://json-schema.org/draft/2020-12/schema";
     private final String id;
     private final String title;
     private final String description;

--- a/src/hakunapi-cql2/src/main/antlr4/fi/nls/hakunapi/cql2/Cql2Lexer.g4
+++ b/src/hakunapi-cql2/src/main/antlr4/fi/nls/hakunapi/cql2/Cql2Lexer.g4
@@ -1,56 +1,11 @@
 lexer grammar Cql2Lexer;
 
-fragment ALPHA : [A-Za-z];
-fragment DIGIT : [0-9];
-
-COMMA : ',';
-PERIOD : '.';
-COLON : ':';
-UNDERSCORE : '_';
-PLUS : '+';
-MINUS : '-';
-QUOTE : '\'';
-SIGN : PLUS | MINUS;
-
-OPEN_PAREN : '(';
-CLOSE_PAREN : ')';
-
-fragment INT
-    : '0' | [1-9] DIGIT*
-    ;
-
-NUMBER_LITERAL
-    : SIGN? INT
-    | SIGN? INT? (PERIOD [0-9]*)
-    ; 
-
-STRING_LITERAL
-    : QUOTE (~['] | QUOTE QUOTE)* QUOTE
-    ;
-    
-BOOLEAN_LITERAL
-    : 'TRUE' | 'FALSE'
-    ;
-
-COMPARISON_OPERATOR
-    : EQ
-    | LT
-    | GT
-    | NEQ
-    | LTE
-    | GTE
-    ;
-
-EQ : '=';
-LT : '<';
-GT : '>';
-NEQ : LT GT;
-LTE : LT EQ;
-GTE : GT EQ;
-
 LIKE : 'LIKE';
+CASEI : 'CASEI';
+
 BETWEEN : 'BETWEEN';
 IN : 'IN';
+
 IS : 'IS';
 NULL : 'NULL';
 
@@ -58,42 +13,10 @@ AND : 'AND';
 OR : 'OR';
 NOT : 'NOT';
 
-DATE_LITERAL
-    : 'DATE' OPEN_PAREN QUOTE FULL_DATE QUOTE CLOSE_PAREN
-    ;
+DATE : 'DATE';
+TIMESTAMP : 'TIMESTAMP';
+INTERVAL: 'INTERVAL';
 
-TIMESTAMP_LITERAL
-    : 'TIMESTAMP' OPEN_PAREN QUOTE FULL_DATE 'T' TIME_HOUR COLON TIME_MINUTE COLON TIME_SECOND 'Z' QUOTE CLOSE_PAREN
-    ;
-
-FULL_DATE
-    : DATE_YEAR MINUS DATE_MONTH MINUS DATE_DAY
-    ;
-
-DATE_YEAR
-    : DIGIT DIGIT DIGIT DIGIT
-    ;
-    
-DATE_MONTH
-    : DIGIT DIGIT
-    ;
-    
-DATE_DAY
-    : DIGIT DIGIT
-    ;
-
-TIME_HOUR
-    : DIGIT DIGIT
-    ;
-
-TIME_MINUTE
-    : DIGIT DIGIT
-    ;
-
-TIME_SECOND
-    : DIGIT DIGIT (PERIOD DIGIT+)?
-    ;
-    
 POINT : 'POINT';
 LINESTRING : 'LINESTRING';
 POLYGON : 'POLYGON';
@@ -101,20 +24,128 @@ MULTIPOINT : 'MULTIPOINT';
 MULTILINESTRING : 'MULTILINESTRING';
 MULTIPOLYGON : 'MULTIPOLYGON';
 GEOMETRYCOLLECTION : 'GEOMETRYCOLLECTION';
-ENVELOPE : 'ENVELOPE';
 
-SPATIAL_OPERATOR
-    : 'S_CONTAINS'
-    | 'S_CROSSES'
-    | 'S_DISJOINT'
-    | 'S_EQUALS'
-    | 'S_INTERSECTS'
-    | 'S_OVERLAPS'
-    | 'S_TOUCHES'
-    | 'S_WITHIN'
+BBOX : 'BBOX';
+
+COMPARISON_OPERATOR
+    : '='
+    | '<>'
+    | '<'
+    | '>'
+    | '<='
+    | '>='
     ;
 
-IDENTIFIER : ALPHA (IDENTIFIER_PART)* | '"' IDENTIFIER '"';
-IDENTIFIER_PART : ALPHA | DIGIT | UNDERSCORE | COLON | PERIOD;
+SPATIAL_OPERATOR
+    : 'S_INTERSECTS'
+    | 'S_EQUALS'
+    | 'S_DISJOINT'
+    | 'S_TOUCHES'
+    | 'S_WITHIN'
+    | 'S_OVERLAPS'
+    | 'S_CROSSES'
+    | 'S_CONTAINS'
+    ;
+
+COMMA : ',';
+DOUBLE_QUOTE: '"';
+OPEN_PAREN : '(';
+CLOSE_PAREN : ')';
+
+Number
+    : UNumber
+    | SNumber
+    ;
+
+fragment UNumber
+    : UDecimal
+    | Scientific
+    ;
+
+fragment SNumber : [+-]? UNumber;
+
+fragment UDecimal
+    : UInt (PERIOD UInt?)?
+    | PERIOD UInt
+    ;
+
+fragment Scientific : UDecimal 'E' SInt;
+
+fragment UInt : Digit+;
+fragment SInt : [+-]? UInt;
+
+Boolean
+    : 'TRUE'
+    | 'FALSE'
+    ;
+
+Identifier : IdentifierStart IdentifierPart*;
+
+fragment IdentifierPart
+    : IdentifierStart
+    | PERIOD              // "\u002E"
+    | Digit               // 0-9
+    | [\u0300-\u036F]     // combining and diacritical marks
+    | [\u203F-\u2040];    // ‿ and ⁀
+
+fragment IdentifierStart
+    : COLON
+    | UNDERSCORE
+    | [\u0041-\u005A]    // A-Z
+    | [\u0061-\u007A]    // a-z
+    | [\u00C0-\u00D6]    // À-Ö Latin-1 Supplement Letters
+    | [\u00D8-\u00F6]    // Ø-ö Latin-1 Supplement Letters
+    | [\u00F8-\u02FF]    // ø-ÿ Latin-1 Supplement Letters
+    | [\u0370-\u037D]    // Ͱ-ͽ Greek and Coptic (without ";")
+    | [\u037F-\u1FFE]    // See note 1.
+    | [\u200C-\u200D]    // zero width non-joiner and joiner
+    | [\u2070-\u218F]    // See note 2.
+    | [\u2C00-\u2FEF]    // See note 3.
+    | [\u3001-\uD7FF]    // See note 4.
+    | [\uF900-\uFDCF]    // See note 5.
+    | [\uFDF0-\uFFFD]    // See note 6.
+    | [\u{10000}-\u{EFFFF}]  // See note 7.
+;
+
+StringLiteral
+    : QUOTE Character* QUOTE
+    ;
+
+fragment Character
+    : EscapeQuote
+    | Digit
+    | Alpha
+    | WS
+    ;
+
+fragment EscapeQuote
+    : QUOTE QUOTE
+    | BACKSLASH QUOTE
+    ;
+
+fragment Alpha
+    : [\u0007-\u0008]     // bell, bs
+    | [\u0021-\u0026]     // !, ", #, $, %, &
+    | [\u0028-\u002F]     // (, ), *, +, comma, -, ., /
+    | [\u003A-\u0084]     // --+
+    | [\u0086-\u009F]     //   |
+    | [\u00A1-\u167F]     //   |
+    | [\u1681-\u1FFF]     //   |
+    | [\u200B-\u2027]     //   +-> :,;,<,=,>,?,@,A-Z,[,\,],^,_,`,a-z,...
+    | [\u202A-\u202E]     //   |
+    | [\u2030-\u205E]     //   |
+    | [\u2060-\u2FFF]     //   |
+    | [\u3001-\uD7FF]     // --+
+    | [\uE000-\uFFFD]     // See note 8.
+    | [\u{10000}-\u{10FFFF}]  // See note 9.
+    ;
+
+fragment Digit : [0-9];
+
+fragment COLON : ':';
+fragment PERIOD : '.';
+fragment UNDERSCORE : '_';
+fragment QUOTE : '\'';
+fragment BACKSLASH: '\\';
 
 WS : [ \t\r\n]+ -> skip;

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/EmptyExpression.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/EmptyExpression.java
@@ -1,0 +1,11 @@
+package fi.nls.hakunapi.cql2.model;
+
+public class EmptyExpression implements Expression {
+
+    public static final EmptyExpression INSTANCE = new EmptyExpression();
+
+    private EmptyExpression() {
+        // Block init
+    }
+
+}

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/Expression.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/Expression.java
@@ -6,4 +6,8 @@ public interface Expression {
         return visitor.visit(this);
     }
 
+    default public boolean isCasei() {
+        return false;
+    }
+
 }

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/ExpressionVisitor.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/ExpressionVisitor.java
@@ -46,6 +46,8 @@ public interface ExpressionVisitor {
             return visit((SpatialLiteral) e);
         } else if (e instanceof FunctionCall) {
             return visit((FunctionCall) e);
+        } else if (e instanceof EmptyExpression) {
+            return visit((EmptyExpression) e);
         }
 
         throw new IllegalStateException("Unknown Expression " + e.getClass());
@@ -71,5 +73,6 @@ public interface ExpressionVisitor {
     public Object visit(TimestampLiteral p);
 
     public Object visit(FunctionCall fn);
+    public Object visit(EmptyExpression ee);
 
 }

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/LikePredicate.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/LikePredicate.java
@@ -1,13 +1,14 @@
 package fi.nls.hakunapi.cql2.model;
 
 import fi.nls.hakunapi.cql2.model.literal.PropertyName;
+import fi.nls.hakunapi.cql2.model.literal.StringLiteral;
 
 public class LikePredicate implements Expression {
 
     private final PropertyName property;
-    private final String pattern;
+    private final StringLiteral pattern;
 
-    public LikePredicate(PropertyName property, String pattern) {
+    public LikePredicate(PropertyName property, StringLiteral pattern) {
         this.property = property;
         this.pattern = pattern;
     }
@@ -16,7 +17,7 @@ public class LikePredicate implements Expression {
         return property;
     }
 
-    public String getPattern() {
+    public StringLiteral getPattern() {
         return pattern;
     }
 

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/literal/PropertyName.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/literal/PropertyName.java
@@ -5,13 +5,20 @@ import fi.nls.hakunapi.cql2.model.Expression;
 public class PropertyName implements Expression {
 
     private final String value;
+    private final boolean casei;
 
-    public PropertyName(String value) {
+    public PropertyName(String value, boolean casei) {
         this.value = value;
+        this.casei = casei;
     }
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public boolean isCasei() {
+        return casei;
     }
 
 }

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/literal/StringLiteral.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/literal/StringLiteral.java
@@ -3,13 +3,24 @@ package fi.nls.hakunapi.cql2.model.literal;
 public class StringLiteral implements Literal {
     
     private final String value;
+    private final boolean casei;
     
     public StringLiteral(String value) {
+        this(value, false);
+    }
+
+    public StringLiteral(String value, boolean casei) {
         this.value = value;
+        this.casei = casei;
     }
 
     public String getValue() {
         return value;
+    }
+
+    @Override
+    public boolean isCasei() {
+        return casei;
     }
 
 }

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/spatial/SpatialOperator.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/model/spatial/SpatialOperator.java
@@ -2,13 +2,14 @@ package fi.nls.hakunapi.cql2.model.spatial;
 
 public enum SpatialOperator {
 
-    S_CONTAINS,
-    S_CROSSES,
-    S_DISJOINT,
-    S_EQUALS,
     S_INTERSECTS,
-    S_OVERLAPS,
+    S_EQUALS,
+    S_DISJOINT,
     S_TOUCHES,
-    S_WITHIN
+    S_WITHIN,
+    S_OVERLAPS,
+    S_CROSSES,
+    S_CONTAINS,
+    ;
 
 }

--- a/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/text/CQL2Text.java
+++ b/src/hakunapi-cql2/src/main/java/fi/nls/hakunapi/cql2/text/CQL2Text.java
@@ -12,6 +12,7 @@ import fi.nls.hakunapi.core.FilterParser;
 import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.cql2.Cql2Lexer;
 import fi.nls.hakunapi.cql2.Cql2Parser;
+import fi.nls.hakunapi.cql2.model.EmptyExpression;
 import fi.nls.hakunapi.cql2.model.Expression;
 import fi.nls.hakunapi.cql2.model.ExpressionToHakunaFilter;
 
@@ -44,6 +45,10 @@ public class CQL2Text implements FilterParser {
     }
 
     public static Expression parse(String filter, GeometryFactory gf) {
+        if (filter.isBlank()) {
+            return EmptyExpression.INSTANCE;
+        }
+
         CharStream charStream = new CaseChangingCharStream(CharStreams.fromString(filter), true);
 
         Cql2Lexer lexer = new Cql2Lexer(charStream);

--- a/src/hakunapi-cql2/src/test/java/fi/nls/hakunapi/cql2/text/TextParserVisitorTest.java
+++ b/src/hakunapi-cql2/src/test/java/fi/nls/hakunapi/cql2/text/TextParserVisitorTest.java
@@ -2,16 +2,16 @@ package fi.nls.hakunapi.cql2.text;
 
 import static fi.nls.hakunapi.cql2.text.CQL2Text.parse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.junit.Before;
 import org.junit.Test;
 
-import fi.nls.hakunapi.cql2.model.ExpressionToString;
-
 public class TextParserVisitorTest {
-    
+
     private ExpressionToString toString;
-    
+
     @Before
     public void init() {
         toString = new ExpressionToString();
@@ -19,18 +19,105 @@ public class TextParserVisitorTest {
 
     @Test
     public void testCombiningLogicalExpressions() {
-        String input = "foo < +12. AND myprop IS Null OR dog = 'baf' AND ns1:bar.z_2 < 'dog <> bark' AnD (\"bAz\" = true oR qux = false) ANd foo1 <> -.5 AND baz IN ('dog', 'pants') AND foo2 < -2 AND street = 'Tarkk''ampujankatu'";
+        String input = "foo < +12. AND myprop IS Null OR dog = 'baf' AND ns1:bar.z_2 < 'dog <> bark' AnD (bAz = true oR qux = false) ANd foo1 <> -.5 AND baz IN ('dog', 'pants') AND foo2 < -2 AND street = 'Tarkk''ampujankatu'";
         parse(input).accept(toString);
-        String expected = "(\"foo\" < 12.0 AND \"myprop\" IS NULL) OR (\"dog\" = 'baf' AND \"ns1:bar.z_2\" < 'dog <> bark' AND (\"bAz\" = true OR \"qux\" = false) AND \"foo1\" <> -0.5 AND (\"baz\" = 'dog' OR \"baz\" = 'pants') AND \"foo2\" < -2.0 AND \"street\" = 'Tarkk''ampujankatu')";
+        String expected = "(foo < 12.0 AND myprop IS NULL) OR (dog = baf AND ns1:bar.z_2 < dog <> bark AND (bAz = true OR qux = false) AND foo1 <> -0.5 AND (baz = dog OR baz = pants) AND foo2 < -2.0 AND street = Tarkk'ampujankatu)";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPrecedence() {
+        String input = "foo < 0 OR (bar > 0 AND (baz > 0 OR qux < 0))";
+        parse(input).accept(toString);
+        String expected = "foo < 0.0 OR (bar > 0.0 AND (baz > 0.0 OR qux < 0.0))";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEscapedQuoteWithDoubleSingleQuote() {
+        String input = "name = 'Tarkk''ampujankatu'";
+        parse(input).accept(toString);
+        String expected = "name = Tarkk'ampujankatu";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testNoSpaceBetweenOperatorAndOperands() {
+        String input = "component_AdminUnitName_4='MyTest'";
+        parse(input).accept(toString);
+        String expected = "component_AdminUnitName_4 = MyTest";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEscapedQuoteWithBackslash() {
+        String input = "name = 'Tarkk\\'ampujankatu'";
+        parse(input).accept(toString);
+        String expected = "name = Tarkk'ampujankatu";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEscapedQuoteWithAdditionalBackslash() {
+        String input = "name = 'Tarkk\\\\'ampujankatu'";
+        parse(input).accept(toString);
+        String expected = "name = Tarkk\\'ampujankatu";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEscapedQuoteWithTripleSingleQuote() {
+        String input = "name = 'Tarkk'''ampujankatu'";
+        assertThrows(ParseCancellationException.class, () -> parse(input));
+    }
+
+    @Test
+    public void testEscapedQuoteStartsWith() {
+        String input = "greeting = '''ello there mate!'";
+        parse(input).accept(toString);
+        String expected = "greeting = 'ello there mate!";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testEscapedQuoteEndsWith() {
+        String input = "possessive_apostrophe = 'yes, fairies'''";
+        parse(input).accept(toString);
+        String expected = "possessive_apostrophe = yes, fairies'";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMultipleAnd() {
+        String input = "foo < 0 AND bar > 0 AND baz > 0 AND qux < 0";
+        parse(input).accept(toString);
+        String expected = "foo < 0.0 AND bar > 0.0 AND baz > 0.0 AND qux < 0.0";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testTimestampMicros() {
+        String timestamp = "foo < TIMESTAMP('2011-01-01T05:00:00.123456789Z')";
+        parse(timestamp).accept(toString);
+        String expected = "foo < 2011-01-01T05:00:00.123456789Z";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
     @Test
     public void testTimestamp() {
-        String timestamp = "foo < TIMESTAMP('2011-01-01T05:00:00.123456789Z')";
+        String timestamp = "foo < TIMESTAMP('2011-01-01T05:00:00Z')";
         parse(timestamp).accept(toString);
-        String expected = "\"foo\" < '2011-01-01T05:00:00.123456789Z'";
+        String expected = "foo < 2011-01-01T05:00:00Z";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -39,7 +126,7 @@ public class TextParserVisitorTest {
     public void testDate() {
         String date = "foo < dAtE('2011-01-01')";
         parse(date).accept(toString);
-        String expected = "\"foo\" < '2011-01-01'";
+        String expected = "foo < 2011-01-01";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -48,7 +135,7 @@ public class TextParserVisitorTest {
     public void testBetween() {
         String between = "foo BETWEEN 1 AND 3";
         parse(between).accept(toString);
-        String expected = "\"foo\" >= 1.0 AND \"foo\" <= 3.0";
+        String expected = "foo >= 1.0 AND foo <= 3.0";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -57,25 +144,70 @@ public class TextParserVisitorTest {
     public void testNotBetween() {
         String notBetween = "foo NOT BETWEEN 1 AND 3";
         parse(notBetween).accept(toString);
-        String expected = "\"foo\" < 1.0 OR \"foo\" > 3.0";
+        String expected = "foo < 1.0 OR foo > 3.0";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLike() {
+        String input = "baz LIKE 'my_pattern%'";
+        parse(input).accept(toString);
+        String expected = "baz LIKE my_pattern%";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLikeCaseiValue() {
+        String input = "baz LIKE casei('my_pattern%')";
+        parse(input).accept(toString);
+        String expected = "baz ILIKE my_pattern%";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLikeCaseiProperty() {
+        String input = "casei(baz) LIKE casei('my_pattern%')";
+        parse(input).accept(toString);
+        String expected = "baz ILIKE my_pattern%";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testLikeCaseiBoth() {
+        String input = "casei(baz) LIKE casei('my_pattern%')";
+        parse(input).accept(toString);
+        String expected = "baz ILIKE my_pattern%";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
     @Test
     public void testIn() {
-        String in = "\"baz\" in ('dog', 'pants')";
+        String in = "baz in ('dog', 'pants')";
         parse(in).accept(toString);
-        String expected = "\"baz\" = 'dog' OR \"baz\" = 'pants'";
+        String expected = "baz = dog OR baz = pants";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
     @Test
     public void testNotIn() {
-        String notIn = "\"baz\" NOT in ('dog', 'pants')";
+        String notIn = "baz NOT in ('dog', 'pants')";
         parse(notIn).accept(toString);
-        String expected = "\"baz\" <> 'dog' AND \"baz\" <> 'pants'";
+        String expected = "baz <> dog AND baz <> pants";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCaseiIn() {
+        String input = "CASEI(road_class) IN (CASEI('Οδος'),CASEI('Straße'))";
+        parse(input).accept(toString);
+        String expected = "road_class @= Οδος OR road_class @= Straße";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -84,7 +216,16 @@ public class TextParserVisitorTest {
     public void testSIntersectsPoint() {
         String intersects_point = "s_intersects(footprint, point (43.5845 -79.5442))";
         parse(intersects_point).accept(toString);
-        String expected = "S_INTERSECTS(\"footprint\", POINT (43.5845 -79.5442))";
+        String expected = "S_INTERSECTS(footprint, POINT (43.5845 -79.5442))";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSIntersectsMultiPoint() {
+        String input = "s_intersects(footprint, MULTIPOINT ((10 40), (40 30), (20 20), (30 10)))";
+        parse(input).accept(toString);
+        String expected = "S_INTERSECTS(footprint, MULTIPOINT ((10 40), (40 30), (20 20), (30 10)))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -93,7 +234,7 @@ public class TextParserVisitorTest {
     public void testSIntersectsLinestring() {    
         String intersects_line = "s_intersects(footprint, lineString (43.5845 -79.5442, 43.6079 -79.4893))";
         parse(intersects_line).accept(toString);
-        String expected = "S_INTERSECTS(\"footprint\", LINESTRING (43.5845 -79.5442, 43.6079 -79.4893))";
+        String expected = "S_INTERSECTS(footprint, LINESTRING (43.5845 -79.5442, 43.6079 -79.4893))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -102,7 +243,7 @@ public class TextParserVisitorTest {
     public void testSIntersectsPolygon() {
         String intersects_polygon = "s_INTERSECts(footprint, PolyGon ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.6390, 43.5845 -79.5442)))";
         parse(intersects_polygon).accept(toString);
-        String expected = "S_INTERSECTS(\"footprint\", POLYGON ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.639, 43.5845 -79.5442)))";
+        String expected = "S_INTERSECTS(footprint, POLYGON ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.639, 43.5845 -79.5442)))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -111,16 +252,25 @@ public class TextParserVisitorTest {
     public void testCrossesPolygon() {
         String crosses_polygon = "S_CROSSES(footprint, PolyGon ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.6390, 43.5845 -79.5442)))";
         parse(crosses_polygon).accept(toString);
-        String expected = "S_CROSSES(\"footprint\", POLYGON ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.639, 43.5845 -79.5442)))";
+        String expected = "S_CROSSES(footprint, POLYGON ((43.5845 -79.5442, 43.6079 -79.4893, 43.5677 -79.4632, 43.6129 -79.3925, 43.6223 -79.3238, 43.6576 -79.3163, 43.7945 -79.1178, 43.8144 -79.1542, 43.8555 -79.1714, 43.7509 -79.639, 43.5845 -79.5442)))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
     @Test
-    public void testSIntersectsEnvelope() {        
-        String intersects_envelope = "S_Intersects(footprint, envelope (43.5845 -79.5442, 43.6079 -79.7893))";
+    public void testSIntersectsBbox() {
+        String intersects_envelope = "S_Intersects(footprint, bbox (43.5845, -79.5442, 43.6079, -79.7893))";
         parse(intersects_envelope).accept(toString);
-        String expected = "S_INTERSECTS(\"footprint\", POLYGON ((43.5845 -79.5442, 43.6079 -79.5442, 43.6079 -79.7893, 43.5845 -79.7893, 43.5845 -79.5442)))";
+        String expected = "S_INTERSECTS(footprint, POLYGON ((43.5845 -79.5442, 43.6079 -79.5442, 43.6079 -79.7893, 43.5845 -79.7893, 43.5845 -79.5442)))";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testSIntersectsGeometryCollection() {
+        String intersects_line = "s_intersects(footprint, GeometryCollection (lineString (43.5845 -79.5442, 43.6079 -79.4893), point (43.5845 -79.5442)))";
+        parse(intersects_line).accept(toString);
+        String expected = "S_INTERSECTS(footprint, GEOMETRYCOLLECTION (LINESTRING (43.5845 -79.5442, 43.6079 -79.4893), POINT (43.5845 -79.5442)))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
@@ -129,19 +279,27 @@ public class TextParserVisitorTest {
     public void testIntersectsBufferLine() {
         String intersects_buffer_line = "S_Intersects(footprint, BUFFER( lineString (43.5845 -79.5442, 43.6079 -79.4893), 10))";
         parse(intersects_buffer_line).accept(toString);
-        String expected = "S_INTERSECTS(\"footprint\", BUFFER(LINESTRING (43.5845 -79.5442, 43.6079 -79.4893), 10.0))";
+        String expected = "S_INTERSECTS(footprint, BUFFER(LINESTRING (43.5845 -79.5442, 43.6079 -79.4893), 10.0))";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
     @Test
-    public void testRandomFunctionCall() {
-        String function_call = "foo > foo(1, 2, 3)";
+    public void testRandomFunctionCalls() {
+        String function_call = "foo > foo(bar(1), 2, 3)";
         parse(function_call).accept(toString);
-        String expected = "\"foo\" > foo(1.0, 2.0, 3.0)";
+        String expected = "foo > foo(bar(1.0), 2.0, 3.0)";
         String actual = toString.finish();
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testEmptyString() {
+        String function_call = " ";
+        parse(function_call).accept(toString);
+        String expected = "";
+        String actual = toString.finish();
+        assertEquals(expected, actual);
+    }
 
 }

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
@@ -53,7 +53,7 @@
     <h3>Queryable properties</h3>
     <p><a href="collections/${model.id}/queryables">Find out properties usable in filters</a></p>
 
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
@@ -38,7 +38,7 @@
       </#list>
     </ul>
     
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
@@ -38,7 +38,7 @@
     </#list>
     </ul>
     
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
@@ -59,7 +59,7 @@
       </tbody>
     </table>
        
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi/footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -106,7 +106,7 @@
       </ul>
     </nav>
 
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
@@ -108,7 +108,7 @@
       </ul>
     </nav>
 
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
@@ -61,7 +61,7 @@
       </tbody>
     </table>
        
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
@@ -41,7 +41,7 @@
       </#list>
     </ul>
 
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
@@ -47,7 +47,7 @@
       <p><a href="conformance">OGC API conformance classes implemented by this server</a></p>
     </div>
     
-    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi &copy; 2023</footer>
+    <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
 <script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>

--- a/src/hakunapi-jsonfg/src/test/resources/fi/nls/hakunapi/jsonfg/featurecollection.min.json
+++ b/src/hakunapi-jsonfg/src/test/resources/fi/nls/hakunapi/jsonfg/featurecollection.min.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://beta.schemas.opengis.net/json-fg/featurecollection.min.json",
     "title": "a JSON-FG Feature Collection",
     "description": "This JSON Schema is part of JSON-FG version 0.1.1",

--- a/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/SDOSimpleSource.java
+++ b/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/SDOSimpleSource.java
@@ -277,6 +277,8 @@ public class SDOSimpleSource extends SQLSimpleSource implements SimpleSource {
 
 		ft.setPaginationStrategy(getPaginationStrategy(cfg, p, ft));
 
+		ft.setCaseInsensitiveStrategy(getCaseInsensitiveStrategy(cfg, p, ft));
+
 		return ft;
 	}
 

--- a/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/SQLFeatureType.java
+++ b/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/SQLFeatureType.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import fi.nls.hakunapi.core.CaseInsensitiveStrategy;
 import fi.nls.hakunapi.core.FeatureProducer;
 import fi.nls.hakunapi.core.SimpleFeatureType;
 import fi.nls.hakunapi.core.join.Join;
@@ -14,6 +15,7 @@ public abstract class SQLFeatureType extends SimpleFeatureType {
     protected String primaryTable;
     protected List<Join> joins;
     protected DataSource ds;
+    protected CaseInsensitiveStrategy caseInsensitiveStrategy;
 
     public String getDbSchema() {
         return dbSchema;
@@ -45,6 +47,14 @@ public abstract class SQLFeatureType extends SimpleFeatureType {
 
     public void setDatabase(DataSource ds) {
         this.ds = ds;
+    }
+
+    public CaseInsensitiveStrategy getCaseInsensitiveStrategy() {
+        return caseInsensitiveStrategy;
+    }
+
+    public void setCaseInsensitiveStrategy(CaseInsensitiveStrategy caseInsensitiveStrategy) {
+        this.caseInsensitiveStrategy = caseInsensitiveStrategy;
     }
 
     public abstract FeatureProducer getFeatureProducer() ;

--- a/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/SQLSimpleSource.java
+++ b/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/SQLSimpleSource.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import fi.nls.hakunapi.core.CaseInsensitiveStrategy;
 import fi.nls.hakunapi.core.HakunapiPlaceholder;
 import fi.nls.hakunapi.core.PaginationStrategy;
 import fi.nls.hakunapi.core.PaginationStrategyCursor;
@@ -487,6 +488,17 @@ public abstract class SQLSimpleSource implements SimpleSource {
         default:
             throw new IllegalArgumentException("Unknown pagination strategy " + paginationStrategy);
         }
+    }
+
+    protected CaseInsensitiveStrategy getCaseInsensitiveStrategy(HakunaConfigParser cfg, String p, SimpleFeatureType sft) {
+        String caseiStrategy = cfg.get(p + "casei");
+        if (caseiStrategy == null) {
+            return CaseInsensitiveStrategy.LOWER;
+        }
+        return Arrays.stream(CaseInsensitiveStrategy.values())
+                .filter(x -> x.name().equalsIgnoreCase(caseiStrategy))
+                .findAny()
+                .get();
     }
 
     protected PaginationStrategyCursor getPaginationCursor(HakunaConfigParser cfg, String p, SimpleFeatureType sft) {

--- a/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/filter/SQLComparison.java
+++ b/src/hakunapi-source-oracle/src/main/java/fi/nls/hakunapi/simple/sdo/sql/filter/SQLComparison.java
@@ -12,22 +12,38 @@ import java.util.UUID;
 
 import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.core.property.HakunaProperty;
+import fi.nls.hakunapi.simple.sdo.SDOFeatureType;
+import fi.nls.hakunapi.simple.sdo.sql.SQLFeatureType;
 import fi.nls.hakunapi.simple.sdo.sql.SQLUtil;
 
 public abstract class SQLComparison implements SQLFilter {
 
     @Override
     public String toSQL(Filter filter) {
+        String property = caseInsensitiveWrap(filter, SQLUtil.toSQL(filter.getProp()));
+        return property + getOp() + "?";
+    }
+
+    protected static String caseInsensitiveWrap(Filter filter, String propertyName) {
+        if (!filter.isCaseInsensitive()) {
+            return propertyName;
+        }
         HakunaProperty prop = filter.getProp();
-        return SQLUtil.toSQL(prop) + getOp() + "?";
+        SDOFeatureType sft = (SDOFeatureType) prop.getFeatureType();
+        switch (sft.getCaseInsensitiveStrategy()) {
+        case LOWER: return String.format("lower(%s)", propertyName);
+        case UPPER: return String.format("upper(%s)", propertyName);
+        default: throw new IllegalArgumentException("Unknown caseInsensitiveStrategy " + sft.getCaseInsensitiveStrategy());
+        }
     }
 
     @Override
     public int bind(Filter filter, Connection c, PreparedStatement ps, int i) throws SQLException {
-        return doBind(filter.getValue(), c, ps, i);
+        return doBind(filter, c, ps, i);
     }
     
-    protected static int doBind(Object value, Connection c, PreparedStatement ps, int i) throws SQLException {
+    protected static int doBind(Filter filter, Connection c, PreparedStatement ps, int i) throws SQLException {
+        Object value = filter.getValue();
         if (value instanceof Boolean) {
             ps.setBoolean(i, (Boolean) value);
         } else if (value instanceof Integer) {
@@ -39,7 +55,21 @@ public abstract class SQLComparison implements SQLFilter {
         } else if (value instanceof Double) {
             ps.setDouble(i, (Double) value);
         } else if (value instanceof String) {
-            ps.setString(i, (String) value);
+            String s = (String) value;
+            if (filter.isCaseInsensitive()) {
+                SQLFeatureType sft = (SQLFeatureType) filter.getProp().getFeatureType();
+                switch (sft.getCaseInsensitiveStrategy()) {
+                case LOWER:
+                    s = s.toLowerCase();
+                    break;
+                case UPPER:
+                    s = s.toUpperCase();
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown caseInsensitiveStrategy " + sft.getCaseInsensitiveStrategy());
+                }
+            }
+            ps.setString(i, s);
         } else if (value instanceof LocalDate) {
             ps.setDate(i, Date.valueOf((LocalDate) value));
         } else if (value instanceof Instant) {

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import fi.nls.hakunapi.core.CaseInsensitiveStrategy;
 import fi.nls.hakunapi.core.HakunapiPlaceholder;
 import fi.nls.hakunapi.core.PaginationStrategy;
 import fi.nls.hakunapi.core.PaginationStrategyCursor;
@@ -386,6 +387,8 @@ public class PostGISSimpleSource implements SimpleSource {
 
         ft.setPaginationStrategy(getPaginationStrategy(cfg, p, ft));
 
+        ft.setCaseInsensitiveStrategy(getCaseInsensitiveStrategy(cfg, p, ft));
+
         return ft;
     }
 
@@ -482,6 +485,17 @@ public class PostGISSimpleSource implements SimpleSource {
         default:
             throw new IllegalArgumentException("Unknown pagination strategy " + paginationStrategy);
         }
+    }
+
+    private CaseInsensitiveStrategy getCaseInsensitiveStrategy(HakunaConfigParser cfg, String p, SimpleFeatureType sft) {
+        String caseiStrategy = cfg.get(p + "casei");
+        if (caseiStrategy == null) {
+            return CaseInsensitiveStrategy.LOWER;
+        }
+        return Arrays.stream(CaseInsensitiveStrategy.values())
+                .filter(x -> x.name().equalsIgnoreCase(caseiStrategy))
+                .findAny()
+                .get();
     }
 
     private PaginationStrategyCursor getPaginationCursor(HakunaConfigParser cfg, String p, SimpleFeatureType sft) {

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SQLFeatureType.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SQLFeatureType.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import fi.nls.hakunapi.core.CaseInsensitiveStrategy;
 import fi.nls.hakunapi.core.FeatureProducer;
 import fi.nls.hakunapi.core.SimpleFeatureType;
 import fi.nls.hakunapi.core.join.Join;
@@ -14,6 +15,7 @@ public class SQLFeatureType extends SimpleFeatureType {
     private String primaryTable;
     private List<Join> joins;
     private DataSource ds;
+    private CaseInsensitiveStrategy caseInsensitiveStrategy;
 
     public String getDbSchema() {
         return dbSchema;
@@ -50,6 +52,14 @@ public class SQLFeatureType extends SimpleFeatureType {
     @Override
     public FeatureProducer getFeatureProducer() {
         return new SimplePostGIS(ds);
+    }
+
+    public CaseInsensitiveStrategy getCaseInsensitiveStrategy() {
+        return caseInsensitiveStrategy;
+    }
+
+    public void setCaseInsensitiveStrategy(CaseInsensitiveStrategy caseInsensitiveStrategy) {
+        this.caseInsensitiveStrategy = caseInsensitiveStrategy;
     }
 
 }

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/filter/SQLComparison.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/filter/SQLComparison.java
@@ -12,22 +12,37 @@ import java.util.UUID;
 
 import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.core.property.HakunaProperty;
+import fi.nls.hakunapi.simple.postgis.SQLFeatureType;
 import fi.nls.hakunapi.simple.postgis.SQLUtil;
 
 public abstract class SQLComparison implements SQLFilter {
 
     @Override
     public String toSQL(Filter filter) {
+        String property = caseInsensitiveWrap(filter, SQLUtil.toSQL(filter.getProp()));
+        return property + getOp() + "?";
+    }
+
+    protected static String caseInsensitiveWrap(Filter filter, String propertyName) {
+        if (!filter.isCaseInsensitive()) {
+            return propertyName;
+        }
         HakunaProperty prop = filter.getProp();
-        return SQLUtil.toSQL(prop) + getOp() + "?";
+        SQLFeatureType sft = (SQLFeatureType) prop.getFeatureType();
+        switch (sft.getCaseInsensitiveStrategy()) {
+        case LOWER: return String.format("lower(%s)", propertyName);
+        case UPPER: return String.format("upper(%s)", propertyName);
+        default: throw new IllegalArgumentException("Unknown caseInsensitiveStrategy " + sft.getCaseInsensitiveStrategy());
+        }
     }
 
     @Override
     public int bind(Filter filter, Connection c, PreparedStatement ps, int i) throws SQLException {
-        return doBind(filter.getValue(), c, ps, i);
+        return doBind(filter, c, ps, i);
     }
     
-    protected static int doBind(Object value, Connection c, PreparedStatement ps, int i) throws SQLException {
+    protected static int doBind(Filter filter, Connection c, PreparedStatement ps, int i) throws SQLException {
+        Object value = filter.getValue();
         if (value instanceof Boolean) {
             ps.setBoolean(i, (Boolean) value);
         } else if (value instanceof Integer) {
@@ -39,7 +54,21 @@ public abstract class SQLComparison implements SQLFilter {
         } else if (value instanceof Double) {
             ps.setDouble(i, (Double) value);
         } else if (value instanceof String) {
-            ps.setString(i, (String) value);
+            String s = (String) value;
+            if (filter.isCaseInsensitive()) {
+                SQLFeatureType sft = (SQLFeatureType) filter.getProp().getFeatureType();
+                switch (sft.getCaseInsensitiveStrategy()) {
+                case LOWER:
+                    s = s.toLowerCase();
+                    break;
+                case UPPER:
+                    s = s.toUpperCase();
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown caseInsensitiveStrategy " + sft.getCaseInsensitiveStrategy());
+                }
+            }
+            ps.setString(i, s);
         } else if (value instanceof LocalDate) {
             ps.setDate(i, Date.valueOf((LocalDate) value));
         } else if (value instanceof Instant) {
@@ -54,6 +83,6 @@ public abstract class SQLComparison implements SQLFilter {
         return i + 1;
     }
 
-    public abstract String getOp(); 
+    public abstract String getOp();
 
 }

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/filter/SQLLike.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/filter/SQLLike.java
@@ -6,7 +6,7 @@ import java.sql.SQLException;
 
 import fi.nls.hakunapi.core.filter.Filter;
 import fi.nls.hakunapi.core.filter.LikeFilter;
-import fi.nls.hakunapi.core.property.HakunaProperty;
+import fi.nls.hakunapi.simple.postgis.SQLFeatureType;
 import fi.nls.hakunapi.simple.postgis.SQLUtil;
 
 public class SQLLike implements SQLFilter {
@@ -17,16 +17,7 @@ public class SQLLike implements SQLFilter {
             throw new UnsupportedOperationException();
         }
 
-        LikeFilter likeFilter = (LikeFilter) filter;
-        HakunaProperty prop = filter.getProp();
-        
-        String propertyName;
-        if (likeFilter.isCaseInsensitive()) {
-            propertyName = String.format("lower(%s)", SQLUtil.toSQL(prop));
-        } else {
-            propertyName = SQLUtil.toSQL(prop);
-        }
-
+        String propertyName = SQLComparison.caseInsensitiveWrap(filter, SQLUtil.toSQL(filter.getProp()));
         return propertyName + " LIKE ?";
     }
     
@@ -39,7 +30,17 @@ public class SQLLike implements SQLFilter {
         char escape = likeFilter.getEscape();
         value = replaceWildcards(value, wild, single, escape);
         if (likeFilter.isCaseInsensitive()) {
-            value = value.toLowerCase();
+            SQLFeatureType sft = (SQLFeatureType) filter.getProp().getFeatureType();
+            switch (sft.getCaseInsensitiveStrategy()) {
+            case LOWER:
+                value = value.toLowerCase();
+                break;
+            case UPPER:
+                value = value.toUpperCase();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown caseInsensitiveStrategy " + sft.getCaseInsensitiveStrategy());
+            }
         }
         ps.setString(i, value);
         return i + 1;

--- a/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
+++ b/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
@@ -115,12 +115,16 @@ public class HakunaContextListener implements ServletContextListener {
             conformsTo.add(ConformanceClass.QUERYABLES_QUERY_PARAMETERS);
             conformsTo.add(ConformanceClass.FILTER);
             conformsTo.add(ConformanceClass.FEATURES_FILTER);
-            conformsTo.add(ConformanceClass.BASIC_CQL);
-            conformsTo.add(ConformanceClass.ADVANCED_COMPARISON_OPERATORS);
-            conformsTo.add(ConformanceClass.BASIC_SPATIAL_OPERATORS);
-            conformsTo.add(ConformanceClass.SPATIAL_OPERATORS);
-            conformsTo.add(ConformanceClass.CQL2_TEXT_ENCODING);
+
+            conformsTo.add(ConformanceClass.CQL2_TEXT);
             // conformsTo.add(ConformanceClass.CQL2_JSON_ENCODING);
+            conformsTo.add(ConformanceClass.BASIC_CQL2);
+            conformsTo.add(ConformanceClass.ADVANCED_COMPARISON_OPERATORS);
+            conformsTo.add(ConformanceClass.CASE_INSENSITIVE_COMPARISON);
+            conformsTo.add(ConformanceClass.BASIC_SPATIAL_FUNCTIONS);
+            conformsTo.add(ConformanceClass.BAISC_SPATIAL_FUNCTIONS_PLUS);
+            conformsTo.add(ConformanceClass.SPATIAL_FUNCTIONS);
+            conformsTo.add(ConformanceClass.FUNCTIONS);
 
             List<OutputFormat> outputFormats = getOutputFormats(parser);
 

--- a/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
+++ b/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
@@ -111,6 +111,8 @@ public class HakunaContextListener implements ServletContextListener {
             conformsTo.add(ConformanceClass.CRS);
             conformsTo.add(ConformanceClass.GPKG);
 
+            conformsTo.add(ConformanceClass.QUERYABLES);
+            conformsTo.add(ConformanceClass.QUERYABLES_QUERY_PARAMETERS);
             conformsTo.add(ConformanceClass.FILTER);
             conformsTo.add(ConformanceClass.FEATURES_FILTER);
             conformsTo.add(ConformanceClass.BASIC_CQL);

--- a/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/java/fi/nls/hakunapi/simple/webapp/jakarta/features/OgcApiFeaturesPart1CoreTest.java
+++ b/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/java/fi/nls/hakunapi/simple/webapp/jakarta/features/OgcApiFeaturesPart1CoreTest.java
@@ -146,7 +146,7 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 
 		with(response)
 				//
-				.assertThat("$['$schema']", equalTo("https://json-schema.org/draft/2019-09/schema"))
+				.assertThat("$['$schema']", equalTo("https://json-schema.org/draft/2020-12/schema"))
 				//
 				.assertThat("$['$id']", equalTo("https://localhost/hakuna/collections/aallonmurtaja/queryables"))
 				//

--- a/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -115,12 +115,16 @@ public class HakunaContextListener implements ServletContextListener {
             conformsTo.add(ConformanceClass.QUERYABLES_QUERY_PARAMETERS);
             conformsTo.add(ConformanceClass.FILTER);
             conformsTo.add(ConformanceClass.FEATURES_FILTER);
-            conformsTo.add(ConformanceClass.BASIC_CQL);
-            conformsTo.add(ConformanceClass.ADVANCED_COMPARISON_OPERATORS);
-            conformsTo.add(ConformanceClass.BASIC_SPATIAL_OPERATORS);
-            conformsTo.add(ConformanceClass.SPATIAL_OPERATORS);
-            conformsTo.add(ConformanceClass.CQL2_TEXT_ENCODING);
+
+            conformsTo.add(ConformanceClass.CQL2_TEXT);
             // conformsTo.add(ConformanceClass.CQL2_JSON_ENCODING);
+            conformsTo.add(ConformanceClass.BASIC_CQL2);
+            conformsTo.add(ConformanceClass.ADVANCED_COMPARISON_OPERATORS);
+            conformsTo.add(ConformanceClass.CASE_INSENSITIVE_COMPARISON);
+            conformsTo.add(ConformanceClass.BASIC_SPATIAL_FUNCTIONS);
+            conformsTo.add(ConformanceClass.BAISC_SPATIAL_FUNCTIONS_PLUS);
+            conformsTo.add(ConformanceClass.SPATIAL_FUNCTIONS);
+            conformsTo.add(ConformanceClass.FUNCTIONS);
 
             List<OutputFormat> outputFormats = getOutputFormats(parser);
 

--- a/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -111,6 +111,8 @@ public class HakunaContextListener implements ServletContextListener {
             conformsTo.add(ConformanceClass.CRS);
             conformsTo.add(ConformanceClass.GPKG);
 
+            conformsTo.add(ConformanceClass.QUERYABLES);
+            conformsTo.add(ConformanceClass.QUERYABLES_QUERY_PARAMETERS);
             conformsTo.add(ConformanceClass.FILTER);
             conformsTo.add(ConformanceClass.FEATURES_FILTER);
             conformsTo.add(ConformanceClass.BASIC_CQL);

--- a/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
+++ b/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
@@ -147,7 +147,7 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 
 		with(response)
 				//
-				.assertThat("$['$schema']", equalTo("https://json-schema.org/draft/2019-09/schema"))
+				.assertThat("$['$schema']", equalTo("https://json-schema.org/draft/2020-12/schema"))
 				//
 				.assertThat("$['$id']", equalTo("https://localhost/hakuna/collections/aallonmurtaja/queryables"))
 				//


### PR DESCRIPTION
This is probably still missing something, thorough testing is needed before finalizing 1.5.0 release.

1) Refactoring and fixing Part 3/CQL2 conformance issues
- Largely refactor CQL2Text Lexer and Parser
- Fix conformance URIs
- Fix bug with cql2-text MultiPoints being parsed wrong
- Use jsonschema 2020-12 instead of 2019-09

2) Case insensitive comparisons
- `fi.nls.hakunapi.core.filter.Filter` now has a new boolean property `caseInsensitive` which remarks if the comparison/filter should be handled in a caseInsensitive manner
- PostGIS and Oracle sources can now perform caseInsensitive comparisons on EqualTo/NotEqualTo Filters in addition to LIKE
- Add new concept `CaseInsensitiveStrategy`
  - Instead of always doing `lower(my_prop)` allow configuring each Collection (`(SQL)FeatureType`) to have their own strategy  (depending on how you indexed it)
  - Two CaseInsensitiveStrategys: LOWER (default) and UPPER
    - lower(my_prop) = lower('Value') vs. upper(my_prop) = 'VALUE'
  - Configure with `collections.<collectionId>.casei=upper` (value is matched to enum case-insensitively)
    - Supported by both PostGIS and Oracle sources

3) Minor cleaning
- Remove Copyright and year from default HTML templates as hakunapi is not copyrighted and the year was already out-of-date.

