### PR TITLE
Allow pg source to perform the coordinate transformation/projection 

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureType.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureType.java
@@ -42,6 +42,9 @@ public interface FeatureType {
     public List<Filter> getStaticFilters();
     
     public ProjectionTransformerFactory getProjectionTransformerFactory();
+    public default boolean isSourceWillProject() {
+        return false;
+    }
 
     public HakunaGeometryDimension getGeomDimension();
     public PaginationStrategy getPaginationStrategy();

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/QueryContext.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/QueryContext.java
@@ -3,6 +3,7 @@ package fi.nls.hakunapi.core;
 public class QueryContext {
 
     private int srid;
+    private boolean sourceShouldProjectToSrid;
 
     public int getSRID() {
         return srid;
@@ -10,6 +11,14 @@ public class QueryContext {
 
     public void setSRID(int srid) {
         this.srid = srid;
+    }
+
+    public boolean isSourceShouldProjectToSrid() {
+        return sourceShouldProjectToSrid;
+    }
+
+    public void setSourceShouldProjectToSrid(boolean sourceShouldProjectToSrid) {
+        this.sourceShouldProjectToSrid = sourceShouldProjectToSrid;
     }
 
 }

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/property/simple/HakunaPropertyGeometry.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/property/simple/HakunaPropertyGeometry.java
@@ -106,6 +106,10 @@ public class HakunaPropertyGeometry extends HakunaPropertyDynamic {
 
     @Override
     public BiConsumer<ValueProvider, ValueContainer> getMapperFunction(int iValueProvider, int iValueContainer, QueryContext ctx) {
+        if (ctx.isSourceShouldProjectToSrid()) {
+            return (vp, vc) -> vc.setObject(iValueContainer, vp.getHakunaGeometry(iValueProvider));
+        }
+
         ProjectionTransformer t;
         try {
             t = getFeatureType().getProjectionTransformerFactory().getTransformer(getStorageSRID(), ctx.getSRID());

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/PostGISSimpleSource.java
@@ -389,6 +389,8 @@ public class PostGISSimpleSource implements SimpleSource {
 
         ft.setCaseInsensitiveStrategy(getCaseInsensitiveStrategy(cfg, p, ft));
 
+        ft.setSourceShouldProject(getSourceShouldProject(cfg, p));
+
         return ft;
     }
 
@@ -496,6 +498,10 @@ public class PostGISSimpleSource implements SimpleSource {
                 .filter(x -> x.name().equalsIgnoreCase(caseiStrategy))
                 .findAny()
                 .get();
+    }
+
+    private boolean getSourceShouldProject(HakunaConfigParser cfg, String p) {
+        return Boolean.parseBoolean(cfg.get(p + "sourceproj", "false"));
     }
 
     private PaginationStrategyCursor getPaginationCursor(HakunaConfigParser cfg, String p, SimpleFeatureType sft) {

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SQLFeatureType.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SQLFeatureType.java
@@ -16,6 +16,7 @@ public class SQLFeatureType extends SimpleFeatureType {
     private List<Join> joins;
     private DataSource ds;
     private CaseInsensitiveStrategy caseInsensitiveStrategy;
+    private boolean sourceWillProject;
 
     public String getDbSchema() {
         return dbSchema;
@@ -60,6 +61,15 @@ public class SQLFeatureType extends SimpleFeatureType {
 
     public void setCaseInsensitiveStrategy(CaseInsensitiveStrategy caseInsensitiveStrategy) {
         this.caseInsensitiveStrategy = caseInsensitiveStrategy;
+    }
+
+    @Override
+    public boolean isSourceWillProject() {
+        return sourceWillProject;
+    }
+
+    public void setSourceShouldProject(boolean sourceWillProject) {
+        this.sourceWillProject = sourceWillProject;
     }
 
 }

--- a/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SimplePostGIS.java
+++ b/src/hakunapi-source-postgis/src/main/java/fi/nls/hakunapi/simple/postgis/SimplePostGIS.java
@@ -64,6 +64,7 @@ public class SimplePostGIS implements FeatureProducer {
         
         QueryContext ctx = new QueryContext();
         ctx.setSRID(request.getSRID());
+        ctx.setSourceShouldProjectToSrid(ft.isSourceWillProject());
 
         StringBuilder q = new StringBuilder();
         List<ValueMapper> mappers = PostGISUtil.select(q, col.getProperties(), ctx);


### PR DESCRIPTION
Currently hakunapi handles all coordinate transformations inside Java code. While this is originally by-design (when the amount of calculation doesn't change, do it in application level instead of db) some might prefer postgis handle them for you (for precision etc).

This is also a step towards dropping `hakunapi-proj-gt` from .war files generated by `hakunapi-simple-webapp-*` projects for smaller war packages and startup time.

This partially handles #58 as all geometries in Filters are still transformed to storage SRID by hakunapi itself. Changing that in the  future shouldn't be a big deal.