### PR TITLE
Return collections in the order they appear in configuration

### DIFF
--- a/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
+++ b/webapp-jakarta/hakunapi-simple-webapp-jakarta/src/main/java/fi/nls/hakunapi/simple/webapp/jakarta/HakunaContextListener.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class HakunaContextListener implements ServletContextListener {
             }
             List<SRIDCode> knownSrids = parser.getKnownSrids();
 
-            Map<String, FeatureType> collections = new HashMap<>();
+            Map<String, FeatureType> collections = new LinkedHashMap<>();
             for (String collectionId : parser.readCollectionIds()) {
                 FeatureType ft = parser.readCollection(configPath, sourcesByType, collectionId);
                 collections.put(collectionId, ft);

--- a/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/java/fi/nls/hakunapi/simple/webapp/jakarta/features/OgcApiFeaturesPart1CoreTest.java
+++ b/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/java/fi/nls/hakunapi/simple/webapp/jakarta/features/OgcApiFeaturesPart1CoreTest.java
@@ -92,6 +92,17 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 				.assertThat("$.collections[?(@.id == 'should_not_exist')]", is(collectionWithSize(equalTo(0))));
 	}
 
+    @Test
+    public void testCollectionsOrder() {
+        final String response = target("/collections").request().get(String.class);
+        LOG.info(response);
+
+        with(response)
+                //
+                .assertThat("$.collections[0].id", equalTo("test_collection"))
+                .assertThat("$.collections[1].id", equalTo("aallonmurtaja"));
+    }
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testCollectionsAallonmurtaja() {

--- a/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/resources/hakuna/hakuna.properties
+++ b/webapp-jakarta/hakunapi-simple-webapp-test-jakarta/src/test/resources/hakuna/hakuna.properties
@@ -25,7 +25,7 @@ getfeatures.limit.max=10000
 db.classes=fi.nls.hakunapi.source.HakunaTestSource
 db=db
 
-collections=aallonmurtaja,test_collection
+collections=test_collection,aallonmurtaja
 collections.aallonmurtaja.type=test
 collections.aallonmurtaja.db=db
 collections.aallonmurtaja.table=aallonmurtaja

--- a/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
+++ b/webapp-javax/hakunapi-simple-webapp-javax/src/main/java/fi/nls/hakunapi/simple/webapp/javax/HakunaContextListener.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -97,7 +98,7 @@ public class HakunaContextListener implements ServletContextListener {
             }
             List<SRIDCode> knownSrids = parser.getKnownSrids();
 
-            Map<String, FeatureType> collections = new HashMap<>();
+            Map<String, FeatureType> collections = new LinkedHashMap<>();
             for (String collectionId : parser.readCollectionIds()) {
                 FeatureType ft = parser.readCollection(configPath, sourcesByType, collectionId);
                 collections.put(collectionId, ft);

--- a/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
+++ b/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/java/fi/nls/hakunapi/simple/webapp/javax/features/OgcApiFeaturesPart1CoreTest.java
@@ -93,6 +93,17 @@ public class OgcApiFeaturesPart1CoreTest extends JerseyTest {
 				.assertThat("$.collections[?(@.id == 'should_not_exist')]", is(collectionWithSize(equalTo(0))));
 	}
 
+    @Test
+    public void testCollectionsOrder() {
+        final String response = target("/collections").request().get(String.class);
+        LOG.info(response);
+
+        with(response)
+                //
+                .assertThat("$.collections[0].id", equalTo("test_collection"))
+                .assertThat("$.collections[1].id", equalTo("aallonmurtaja"));
+    }
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testCollectionsAallonmurtaja() {

--- a/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/resources/hakuna/hakuna.properties
+++ b/webapp-javax/hakunapi-simple-webapp-test-javax/src/test/resources/hakuna/hakuna.properties
@@ -25,7 +25,7 @@ getfeatures.limit.max=10000
 db.classes=fi.nls.hakunapi.source.HakunaTestSource
 db=db
 
-collections=aallonmurtaja,test_collection
+collections=test_collection,aallonmurtaja
 collections.aallonmurtaja.type=test
 collections.aallonmurtaja.db=db
 collections.aallonmurtaja.table=aallonmurtaja


### PR DESCRIPTION
Should fix #128 