### PR TITLE
Add option to configure geometry output dimensions for configured srid only 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'adopt'
           architecture: x64
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/FeatureServiceConfig.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -179,6 +180,13 @@ public abstract class FeatureServiceConfig {
 
     public void setKnownSrids(List<SRIDCode> knownSrids) {
         this.knownSrids = knownSrids;
+    }
+    
+    public Optional<SRIDCode> getSridCode(int srid) {
+        return knownSrids.stream()
+                .filter(it -> it.getSrid() == srid)
+                .findAny();
+        
     }
 
     public boolean isCrsLatLon(int srid) {

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/SRIDCode.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/SRIDCode.java
@@ -1,13 +1,17 @@
 package fi.nls.hakunapi.core;
 
+import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
+
 public class SRIDCode {
 
     private final int srid;
     private final boolean latLon;
+    private final HakunaGeometryDimension sridDefaultDimension;
 
-    public SRIDCode(int srid, boolean latLon) {
+    public SRIDCode(int srid, boolean latLon, HakunaGeometryDimension dim) {
         this.srid = srid;
         this.latLon = latLon;
+        this.sridDefaultDimension = dim;
     }
 
     public int getSrid() {
@@ -17,5 +21,21 @@ public class SRIDCode {
     public boolean isLatLon() {
         return latLon;
     }
+
+    public HakunaGeometryDimension getOrDefaultDimension(HakunaGeometryDimension ftDefaultDimension) {
+        switch(ftDefaultDimension) {
+        case EPSG: // if configured .geometryDimension=EPSG, let's return sridDefaultDimension when available
+            return sridDefaultDimension != null ? sridDefaultDimension : ftDefaultDimension;
+        case GEOMETRY: 
+        case XY:
+        case XYZ:
+        case XYZM:
+        case DEFAULT:
+        default:
+            return ftDefaultDimension;
+        }
+    }
+    
+    
 
 }

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/config/HakunaConfigParser.java
@@ -159,7 +159,9 @@ public class HakunaConfigParser {
             int srid = Integer.parseInt(sridCode);
             String latLonAttr = get("srid." + sridCode + ".latLon", "false");
             boolean latLon = "true".equalsIgnoreCase(latLonAttr);
-            knownSrids.add(new SRIDCode(srid, latLon));
+            HakunaGeometryDimension geomDimension = getGeometryDims(get("srid."+sridCode+".geometryDimension"));
+            
+            knownSrids.add(new SRIDCode(srid, latLon, geomDimension));
         }
         return knownSrids;
     }
@@ -281,7 +283,7 @@ public class HakunaConfigParser {
         String p = "collections." + collectionId + ".";
 
         int[] srids = getSRIDs(get(p + "srid", get("default.collections.srid")));
-        HakunaGeometryDimension dim = getGeometryDims(collectionId, get(p + "geometryDimension"));
+        HakunaGeometryDimension dim = getGeometryDims(get(p + "geometryDimension"));
 
         SimpleSource source;
         if (sourcesByType.size() == 1) {
@@ -439,16 +441,14 @@ public class HakunaConfigParser {
         }
     }
 
-    private HakunaGeometryDimension getGeometryDims(String collectionId,String dimmode ) {
+    private HakunaGeometryDimension getGeometryDims(String dimmode ) {
         if( dimmode == null ) {
             return HakunaGeometryDimension.DEFAULT;
         }
         try {
             HakunaGeometryDimension dim = HakunaGeometryDimension.valueOf(dimmode);
-            LOG.info("using "+dim+" dimension for "+collectionId);
             return dim;
         } catch (IllegalArgumentException e) {
-            LOG.warn("using default dimension for "+collectionId + " invalid config value "+dimmode);
             return HakunaGeometryDimension.DEFAULT;
         }
     }

--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/CrsUtil.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/util/CrsUtil.java
@@ -58,7 +58,7 @@ public class CrsUtil {
     }
 
     // FIXME: Use some sane logic, for example unit of measure
-    public static int getMaxDecimalCoordinates(int srid) {
+    public static int getDefaultMaxDecimalCoordinates(int srid) {
         switch (srid) {
         case Crs.CRS84_SRID:
         case 4326:
@@ -69,8 +69,5 @@ public class CrsUtil {
         }
     }
 
-    public static HakunaGeometryDimension getGeomDimensionForSrid(HakunaGeometryDimension geomDimension, int srid) {
-        return geomDimension;
-    }
 
 }

--- a/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFG.java
+++ b/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFG.java
@@ -148,7 +148,7 @@ public final class JSONFG {
     }
 
     public static FloatingPointFormatter createCrs84GeometryFormatter() {
-        int crs84maxDecimalsCoordinate = CrsUtil.getMaxDecimalCoordinates(CRS84_SRID);
+        int crs84maxDecimalsCoordinate = CrsUtil.getDefaultMaxDecimalCoordinates(CRS84_SRID);
         int minDecimalsFloat = 0;
         int maxDecimalsFloat = 5;
         int minDecimalsDouble = 0;

--- a/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriter.java
+++ b/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriter.java
@@ -39,7 +39,7 @@ public class JSONFGFeatureCollectionWriter extends HakunaGeoJSONFeatureCollectio
         FloatingPointFormatter fCrs84 = JSONFG.createCrs84GeometryFormatter();
 
         geometryJson = new JSONFGGeometryWriter(json, fCrs84, HakunaGeoJSON.GEOMETRY, true, CRS84_DIM);
-        placeJson = new JSONFGGeometryWriter(json,  decimalFormatter, JSONFG.PLACE, forceLonLat || !crsIsLatLon, CRS84_DIM);
+        placeJson = new JSONFGGeometryWriter(json,  decimalFormatter, JSONFG.PLACE, forceLonLat || !crsIsLatLon, dims);
         propertyGeometryJson.clear();
     }
 

--- a/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriter.java
+++ b/src/hakunapi-jsonfg/src/main/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriter.java
@@ -37,7 +37,7 @@ public class JSONFGSingleFeatureWriter extends HakunaGeoJSONSingleFeatureWriter 
         FloatingPointFormatter fCrs84 = JSONFG.createCrs84GeometryFormatter();
 
         geometryJson = new JSONFGGeometryWriter(json, fCrs84, HakunaGeoJSON.GEOMETRY, true, CRS84_DIM);
-        placeJson = new JSONFGGeometryWriter(json,  decimalFormatter, JSONFG.PLACE, forceLonLat || !crsIsLatLon, CRS84_DIM);
+        placeJson = new JSONFGGeometryWriter(json,  decimalFormatter, JSONFG.PLACE, forceLonLat || !crsIsLatLon, dims);
         propertyGeometryJson.clear();
     }
 

--- a/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriterTest.java
+++ b/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGFeatureCollectionWriterTest.java
@@ -38,7 +38,7 @@ public class JSONFGFeatureCollectionWriterTest {
                 FeatureCollectionWriter fw = new JSONFGFeatureCollectionWriter()) {
 
             int srid =data.PLACE_SRID;
-            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+            int maxDecimalCoordinates = CrsUtil.getDefaultMaxDecimalCoordinates(srid);
 
             fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
@@ -81,7 +81,7 @@ public class JSONFGFeatureCollectionWriterTest {
                 FeatureCollectionWriter fw = new JSONFGFeatureCollectionWriter()) {
 
             int srid =data.PLACE_SRID;
-            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+            int maxDecimalCoordinates = CrsUtil.getDefaultMaxDecimalCoordinates(srid);
 
             fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);

--- a/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriterTest.java
+++ b/src/hakunapi-jsonfg/src/test/java/fi/nls/hakunapi/jsonfg/JSONFGSingleFeatureWriterTest.java
@@ -39,7 +39,7 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
             ValueProvider feat = fs.next();
 
             int srid =data.PLACE_SRID;
-            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+            int maxDecimalCoordinates = CrsUtil.getDefaultMaxDecimalCoordinates(srid);
 
             fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);
@@ -88,7 +88,7 @@ public class JSONFGSingleFeatureWriterTest extends JSONFGTestUtils {
             ValueProvider feat = fs.next();
 
             int srid =data.PLACE_SRID;
-            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
+            int maxDecimalCoordinates = CrsUtil.getDefaultMaxDecimalCoordinates(srid);
 
             fw.init(baos, maxDecimalCoordinates, srid, data.PLACE_SRID_IS_LATLON);
             fw.initGeometryWriter(HakunaGeometryDimension.XY);

--- a/webapp-jakarta/hakunapi-simple-servlet-jakarta/src/main/java/fi/nls/hakunapi/simple/servlet/jakarta/operation/GetItemsOperation.java
+++ b/webapp-jakarta/hakunapi-simple-servlet-jakarta/src/main/java/fi/nls/hakunapi/simple/servlet/jakarta/operation/GetItemsOperation.java
@@ -100,7 +100,7 @@ public class GetItemsOperation implements ParametrizedOperation, DynamicResponse
                     WriteReport report = null;
                     int srid = request.getSRID();
                     
-                    writer.init(out, CrsUtil.getMaxDecimalCoordinates(srid), srid);
+                    writer.init(out, CrsUtil.getDefaultMaxDecimalCoordinates(srid), srid);
 
                     List<GetFeatureCollection> collections = request.getCollections();
 

--- a/webapp-javax/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
+++ b/webapp-javax/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetCollectionItemByIdOperation.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -30,9 +31,11 @@ import fi.nls.hakunapi.core.FeatureStream;
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.FeatureWriter;
 import fi.nls.hakunapi.core.OutputFormat;
+import fi.nls.hakunapi.core.SRIDCode;
 import fi.nls.hakunapi.core.SingleFeatureWriter;
 import fi.nls.hakunapi.core.ValueProvider;
 import fi.nls.hakunapi.core.filter.Filter;
+import fi.nls.hakunapi.core.geom.HakunaGeometryDimension;
 import fi.nls.hakunapi.core.operation.DynamicPathOperation;
 import fi.nls.hakunapi.core.operation.DynamicResponseOperation;
 import fi.nls.hakunapi.core.param.APIParam;
@@ -160,8 +163,13 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
 
             int srid = request.getSRID();
 
-            int maxDecimalCoordinates = CrsUtil.getMaxDecimalCoordinates(srid);
             boolean crsIsLatLon = service.isCrsLatLon(srid);
+            Optional<SRIDCode> sridCode = service.getSridCode(srid);
+            int maxDecimalCoordinates = CrsUtil.getDefaultMaxDecimalCoordinates(srid);
+            HakunaGeometryDimension geomDimension =  c.getFt().getGeomDimension();
+            if(sridCode.isPresent()) {
+                geomDimension = sridCode.get().getOrDefaultDimension(geomDimension);
+            }
 
 
             // Feature response rarely needs 8kb of memory
@@ -169,7 +177,7 @@ public class GetCollectionItemByIdOperation implements DynamicPathOperation, Dyn
             ByteArrayOutputStream baos = new ByteArrayOutputStream(2048);
             writer.init(baos, maxDecimalCoordinates, srid, crsIsLatLon);
             if (c.getFt().getGeom() != null) {
-                writer.initGeometryWriter(CrsUtil.getGeomDimensionForSrid(c.getFt().getGeomDimension(), srid));
+                writer.initGeometryWriter(geomDimension);
             }
 
             int i = 0;

--- a/webapp-javax/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
+++ b/webapp-javax/hakunapi-simple-servlet-javax/src/main/java/fi/nls/hakunapi/simple/servlet/javax/operation/GetItemsOperation.java
@@ -100,7 +100,7 @@ public class GetItemsOperation implements ParametrizedOperation, DynamicResponse
                     WriteReport report = null;
                     int srid = request.getSRID();
                     
-                    writer.init(out, CrsUtil.getMaxDecimalCoordinates(srid), srid);
+                    writer.init(out, CrsUtil.getDefaultMaxDecimalCoordinates(srid), srid);
 
                     List<GetFeatureCollection> collections = request.getCollections();
 


### PR DESCRIPTION
Add configuration option to support output of 3D geometries for configured srids only
This leaves room for improvement, though. Enum values in geometryDimension are somewhat misleading (EPSG,XY,XYZ etc.). 

```
# example

# indicate that geometryDimension should be initialised with srid based configuration
collections.example_collection.geometryDimension=EPSG
collections.example_collection.srid=3067,3046,3047,3048,3873,3874,3875,3876,3877,3878,3879,3880,3881,3882,3883,3884,3885,4258,3857,4326,10774


srid=3067,3046,3047,3048,3873,3874,3875,3876,3877,3878,3879,3880,3881,3882,3883,3884,3885,4258,3857,4326,10774
#...
srid.3067.latLon=false
srid.3067.geometryDimension=XY

srid.10774.latLon=false
srid.10774.geometryDimension=XYZ
```
  