### PR TITLE
Fix JSON links in all HTML pages

### DIFF
--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
@@ -56,7 +56,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
@@ -41,7 +41,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
@@ -41,7 +41,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
@@ -70,7 +70,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -121,7 +121,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
@@ -121,7 +121,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
@@ -72,7 +72,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
@@ -44,7 +44,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
@@ -50,7 +50,7 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.search === "" ? "?f=json" : window.location.search + "&f=json"</script>
+<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?f=json" : window.location.search + "&f=json")</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Should fix #144

Currently the built-in HTML templates all have a link to get the current resource as JSON in the upper right corner. The only issue is that the link doesn't reference current resource all too well. Fix that.