### PR TITLE
Add support for changing background map service in HTML

### DIFF
--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureCollectionWriter.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureCollectionWriter.java
@@ -27,8 +27,13 @@ public class HTMLFeatureCollectionWriter extends HTMLFeatureWriterBase implement
 
     private HTMLFeatureCollection model;
 
+    @Deprecated
     public HTMLFeatureCollectionWriter(Configuration configuration) {
-        super(configuration);
+        this(configuration, new OutputFormatHTMLSettings());
+    }
+
+    public HTMLFeatureCollectionWriter(Configuration configuration, OutputFormatHTMLSettings settings) {
+        super(configuration, settings);
     }
 
     @Override
@@ -43,6 +48,7 @@ public class HTMLFeatureCollectionWriter extends HTMLFeatureWriterBase implement
         this.model = new HTMLFeatureCollection();
         model.setSrid(srid);
         model.setFeatureType(ft);
+        model.setSettings(settings);
         Template template = getTemplate(ft, srid);
         this.environment = template.createProcessingEnvironment(model, new OutputStreamWriter(out, StandardCharsets.UTF_8));
         this.environment.setOutputEncoding(StandardCharsets.UTF_8.name());

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureWriterBase.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLFeatureWriterBase.java
@@ -23,6 +23,7 @@ import fi.nls.hakunapi.html.model.PropertiesContext;
 public abstract class HTMLFeatureWriterBase implements FeatureWriter {
 
     protected final Configuration configuration;
+    protected final OutputFormatHTMLSettings settings;
 
     protected OutputStream out;
 
@@ -38,9 +39,15 @@ public abstract class HTMLFeatureWriterBase implements FeatureWriter {
     protected PropertiesContext properties;
 
     protected int srid;
-    
+
+    @Deprecated
     public HTMLFeatureWriterBase(Configuration configuration) {
+        this(configuration, new OutputFormatHTMLSettings());
+    }
+
+    public HTMLFeatureWriterBase(Configuration configuration, OutputFormatHTMLSettings settings) {
         this.configuration = configuration;
+        this.settings = settings;
     }
 
     @Override

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLSingleFeatureWriter.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/HTMLSingleFeatureWriter.java
@@ -24,8 +24,13 @@ public class HTMLSingleFeatureWriter extends HTMLFeatureWriterBase implements Si
     private static final String TEMPLATE_GENERIC_SRID = "feature_%d.ftl";
     private static final String TEMPLATE_GENERIC = "feature.ftl";
 
+    @Deprecated
     public HTMLSingleFeatureWriter(Configuration configuration) {
         super(configuration);
+    }
+
+    public HTMLSingleFeatureWriter(Configuration configuration, OutputFormatHTMLSettings settings) {
+        super(configuration, settings);
     }
 
     @Override
@@ -45,6 +50,7 @@ public class HTMLSingleFeatureWriter extends HTMLFeatureWriterBase implements Si
         this.feature = new HTMLFeature();
         this.feature.setId(fid);
         this.feature.setFeatureType(ft);
+        this.feature.setSettings(settings);
         this.properties = new PropertiesContextMap(feature.getProperties(), null);
         Template template = getTemplate(ft, srid);
         this.environment = template.createProcessingEnvironment(feature, new OutputStreamWriter(out, StandardCharsets.UTF_8));

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/OutputFormatHTML.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/OutputFormatHTML.java
@@ -11,9 +11,11 @@ public class OutputFormatHTML implements OutputFormat {
     public static final String MIME_TYPE = "text/html";
 
     private final Configuration configuration;
+    private final OutputFormatHTMLSettings settings;
 
-    public OutputFormatHTML(Configuration configuration) {
+    public OutputFormatHTML(Configuration configuration, OutputFormatHTMLSettings settings) {
         this.configuration = configuration;
+        this.settings = settings;
     }
     
     public Configuration getConfiguration() {
@@ -42,12 +44,12 @@ public class OutputFormatHTML implements OutputFormat {
 
     @Override
     public FeatureCollectionWriter getFeatureCollectionWriter() {
-        return new HTMLFeatureCollectionWriter(configuration);
+        return new HTMLFeatureCollectionWriter(configuration, settings);
     }
 
     @Override
     public SingleFeatureWriter getSingleFeatureWriter() {
-        return new HTMLSingleFeatureWriter(configuration);
+        return new HTMLSingleFeatureWriter(configuration, settings);
     }
 
 }

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/OutputFormatHTMLSettings.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/OutputFormatHTMLSettings.java
@@ -1,0 +1,35 @@
+package fi.nls.hakunapi.html;
+
+/**
+ * Only public string fields allowed in this class
+ * @see fi.nls.hakunapi.html.OutputFormatFactoryHTML
+ */
+public class OutputFormatHTMLSettings {
+
+    static final OutputFormatHTMLSettings OSM;
+    static {
+        OSM = new OutputFormatHTMLSettings();
+        OSM.tileUrl = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+        OSM.tileAttribution = "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors";
+    }
+
+    public String tileUrl;
+    public String tileAttribution;
+
+    public String getTileUrl() {
+        return tileUrl;
+    }
+
+    public void setTileUrl(String tileUrl) {
+        this.tileUrl = tileUrl;
+    }
+
+    public String getTileAttribution() {
+        return tileAttribution;
+    }
+
+    public void setTileAttribution(String tileAttribution) {
+        this.tileAttribution = tileAttribution;
+    }
+
+}

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLFeature.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLFeature.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.schemas.Link;
+import fi.nls.hakunapi.html.OutputFormatHTMLSettings;
 
 public class HTMLFeature {
     
@@ -14,9 +15,12 @@ public class HTMLFeature {
     private Map<String, Object> properties;
 
     private FeatureType featureType;
+
     private String timestamp;
     private Integer numberReturned;
     private List<Link> links;
+    private OutputFormatHTMLSettings settings;
+
 
     public String getId() {
         return id;
@@ -71,6 +75,14 @@ public class HTMLFeature {
 
     public void setLinks(List<Link> links) {
         this.links = links;
+    }
+
+    public OutputFormatHTMLSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(OutputFormatHTMLSettings settings) {
+        this.settings = settings;
     }
 
 }

--- a/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLFeatureCollection.java
+++ b/src/hakunapi-html/src/main/java/fi/nls/hakunapi/html/model/HTMLFeatureCollection.java
@@ -5,15 +5,18 @@ import java.util.List;
 
 import fi.nls.hakunapi.core.FeatureType;
 import fi.nls.hakunapi.core.schemas.Link;
+import fi.nls.hakunapi.html.OutputFormatHTMLSettings;
 
 public class HTMLFeatureCollection {
 
     private int srid;
     private FeatureType featureType;
     private List<HTMLFeature> features;
+
     private String timestamp;
     private Integer numberReturned;
     private List<Link> links;
+    private OutputFormatHTMLSettings settings;
 
     public HTMLFeatureCollection() {
         this.features = new ArrayList<>();
@@ -65,6 +68,14 @@ public class HTMLFeatureCollection {
 
     public List<Link> getLinks() {
         return links;
+    }
+
+    public OutputFormatHTMLSettings getSettings() {
+        return settings;
+    }
+
+    public void setSettings(OutputFormatHTMLSettings settings) {
+        this.settings = settings;
     }
 
 }

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
@@ -74,8 +74,8 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');
-L.tileLayer('https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/WGS84_Pseudo-Mercator/{z}/{y}/{x}.png?api-key=7cd2ddae-9f2e-481c-99d0-404e7bc7a0b2', {
-    attribution: '&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>'
+L.tileLayer('${settings.tileUrl}', {
+    <#if settings.tileAttribution??>attribution: '${settings.tileAttribution}'</#if>
 }).addTo(map);
 
 <#if geometry??>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -125,8 +125,8 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');
-L.tileLayer('https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/WGS84_Pseudo-Mercator/{z}/{y}/{x}.png?api-key=7cd2ddae-9f2e-481c-99d0-404e7bc7a0b2', {
-    attribution: '&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>'
+L.tileLayer('${settings.tileUrl}', {
+    <#if settings.tileAttribution??>attribution: '${settings.tileAttribution}'</#if>
 }).addTo(map);
 
 var data = [


### PR DESCRIPTION

Should fix #133 

* Add two new properties usable in `featureCollection` and `feature` HTML templates
  * `settings.tileUrl`
  * `settings.tileAttribution`
* Change the built-in HTML template files `featureCollection.ftl` and `feature.ftl` to use said properties
* The value of these properties can be configured via `formats.html.tileUrl` and `formats.html.tileAttribution` (see example below)
  * If nothing is configured the values default to OpenStreetMap tileUrl and tileAttribution
* Does **not** affect the built-in templates `featureCollection_3067.ftl` or `feature_3067.ftl`
  * Current solution of custom template per coordinate reference system isn't scalable, requires separate attention in the future

Example configuration snippet:
```
formats=json,html
formats.html.tileUrl=https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/WGS84_Pseudo-Mercator/{z}/{y}/{x}.png?api-key=<your api key>
formats.html.tileAttribution=&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>
```
