### PR TITLE
Fix JSON links

### DIFF
--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collectionInfo.ftl
@@ -56,7 +56,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/collections.ftl
@@ -41,7 +41,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/conformance.ftl
@@ -41,7 +41,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature.ftl
@@ -70,7 +70,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection.ftl
@@ -121,7 +121,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var map = L.map('map');

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/featureCollection_3067.ftl
@@ -121,7 +121,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/feature_3067.ftl
@@ -72,7 +72,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 <script>
 var crs = new L.Proj.CRS("EPSG:3067",

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/queryables.ftl
@@ -44,7 +44,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
+++ b/src/hakunapi-html/src/main/resources/fi/nls/hakunapi/html/root.ftl
@@ -50,7 +50,11 @@
     <footer class="pt-3 mt-4 text-muted border-top">Powered by hakunapi</footer>
   </div>
 </main>
-<script>document.getElementById("json-link").href = window.location.href + (window.location.search === "" ? "?" : "&") + "f=json"</script>
+<script>
+const url = new URL(window.location.href);
+url.searchParams.set('f', 'json');
+document.getElementById("json-link").href = url.toString();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js" integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Issue is that window.location.href already contains the window.location.search causing duplicated search part

Simplify JSON link construction in all files to just append `(?|&)f=json` to window.location.href based on search being empty (then ?) or not (then &). This should additionally fix JSON links when using any other query parameters (`?filter=` or `?api-key=<key>` for example).
Not ideal still, if current search already contains value for query param `f` then this won't work, but that basically requires the user to manually enter ?f=html, which shouldn't really happen.

Should fix #160 