### PR TITLE
Set bbox SRID always

### DIFF
--- a/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/projection/ProjectionHelper.java
+++ b/src/hakunapi-core/src/main/java/fi/nls/hakunapi/core/projection/ProjectionHelper.java
@@ -9,7 +9,7 @@ import fi.nls.hakunapi.core.property.simple.HakunaPropertyGeometry;
 import fi.nls.hakunapi.core.util.CrsUtil;
 
 public class ProjectionHelper {
-    
+
     public static Geometry reprojectToStorageCRS(HakunaPropertyGeometry prop, Geometry geom) {
         int geomSRID = geom.getSRID();
         int storageSRID = prop.getStorageSRID();
@@ -26,6 +26,7 @@ public class ProjectionHelper {
             throw new IllegalArgumentException(CrsUtil.ERR_UNSUPPORTED_CRS);
         }
         geom = ProjectionHelper.reproject(geom, t);
+        geom.setSRID(storageSRID);
 
         return geom;
     }

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxAntimeridianTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxAntimeridianTest.java
@@ -277,8 +277,8 @@ public class BboxAntimeridianTest {
         Filter filter = getItems.getFilters().get(0);
         Geometry geom = (Geometry) filter.getValue();
 
-        // Should have SRID 4326 and create a geometry (possibly MultiPolygon after reprojection)
-        assertEquals(4326, geom.getSRID());
+        // Should have SRID 84 (reprojected to storageCRS) and create a geometry (possibly MultiPolygon after reprojection)
+        assertEquals(84, geom.getSRID());
         assertEquals("MultiPolygon", geom.getGeometryType());
         assertEquals(2, geom.getNumGeometries());
     }

--- a/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxCrsParamTest.java
+++ b/src/hakunapi-core/src/test/java/fi/nls/hakunapi/core/param/BboxCrsParamTest.java
@@ -121,7 +121,8 @@ public class BboxCrsParamTest {
         assertEquals(1, filters.size());
         Filter filter = filters.get(0);
         Geometry geom = (Geometry) filter.getValue();
-        assertEquals(4326, geom.getSRID());
+        // Geometry should've been reprojected to storageCRS by this point
+        assertEquals(84, geom.getSRID());
         Coordinate bottomLeft = geom.getCoordinates()[0];
         assertEquals(-180, bottomLeft.getX(), 0.0);
         assertEquals(-90, bottomLeft.getY(), 0.0);


### PR DESCRIPTION
When no projection is required (transformation is NOP) setting the SRID of reprojected filtering geometry is skipped. This leads to issues (operation on mixed SRIDs). Fix that.