### PR TITLE
Fix PropertiesCRSRegistry to respect hardcoded known SRIDs

### DIFF
--- a/docker/cfg/addresses.properties
+++ b/docker/cfg/addresses.properties
@@ -42,8 +42,9 @@ getfeatures.limit.max=10000
 
 # Configure known srids (hakunapi will always add 84 (lon, lat) and 4326 (lat, lon))
 srid=3067,4258,3903,10774
-# Let hakunapi know that EPSG:4258 is lat,lon order
+# Let hakunapi know that EPSG:4258 is lat,lon order (+ degrees)
 srid.4258.latLon=true
+srid.4258.degrees=true
 # EPSG:3067 is east,north order (projected)
 srid.3067.latLon=false
 srid.3067.proj4=+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs

--- a/docker/cfg/addresses_gpkg.properties
+++ b/docker/cfg/addresses_gpkg.properties
@@ -18,14 +18,24 @@ servers.dev.description=Development server
 
 # API level configuration
 formats=json,html,gpkg
+formats.html.type=html
+# HTML tile layer configuration per SRID
+formats.html.3067.tileUrl=https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/ETRS-TM35FIN/{z}/{y}/{x}.png?api-key=7cd2ddae-9f2e-481c-99d0-404e7bc7a0b2
+formats.html.3067.tileAttribution=&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>
+formats.html.3067.tileOriginX=-548576
+formats.html.3067.tileOriginY=8388608
 formats.gpkg.dir=/app/features_addresses/tmp
 getfeatures.limit.default=10
 getfeatures.limit.max=10000
 
 # Configure known srids (hakunapi will always add 84 (lon, lat) and 4326 (lat, lon))
 srid=3067,4258
-# Let hakunapi know that EPSG:4258 is lat,lon order
+# EPSG:3067 is east,north order (projected)
+srid.3067.latLon=false
+srid.3067.proj4=+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+# Let hakunapi know that EPSG:4258 is lat,lon order (+ degrees)
 srid.4258.latLon=true
+srid.4258.degrees=true
 
 # Instead of loading PostGIS source drivers (the default) allow and load only GpkgSimpleSource
 db.classes=fi.nls.hakunapi.source.gpkg.GpkgSimpleSource

--- a/examples/finnish_addresses/cfg/addresses.properties
+++ b/examples/finnish_addresses/cfg/addresses.properties
@@ -38,8 +38,9 @@ getfeatures.limit.max=10000
 
 # Configure known srids (hakunapi will always add 84 (lon, lat) and 4326 (lat, lon))
 srid=3067,4258,3903,10774
-# Let hakunapi know that EPSG:4258 is lat,lon order
+# Let hakunapi know that EPSG:4258 is lat,lon order (+ degrees)
 srid.4258.latLon=true
+srid.4258.degrees=true
 # EPSG:3067 is east,north order (projected)
 srid.3067.latLon=false
 srid.3067.proj4=+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs

--- a/examples/finnish_addresses/cfg/addresses_gpkg.properties
+++ b/examples/finnish_addresses/cfg/addresses_gpkg.properties
@@ -18,14 +18,24 @@ servers.dev.description=Development server
 
 # API level configuration
 formats=json,html,gpkg
+formats.html.type=html
+# HTML tile layer configuration per SRID
+formats.html.3067.tileUrl=https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/ETRS-TM35FIN/{z}/{y}/{x}.png?api-key=7cd2ddae-9f2e-481c-99d0-404e7bc7a0b2
+formats.html.3067.tileAttribution=&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>
+formats.html.3067.tileOriginX=-548576
+formats.html.3067.tileOriginY=8388608
 formats.gpkg.dir=/app/features_addresses/tmp
 getfeatures.limit.default=10
 getfeatures.limit.max=10000
 
 # Configure known srids (hakunapi will always add 84 (lon, lat) and 4326 (lat, lon))
 srid=3067,4258
-# Let hakunapi know that EPSG:4258 is lat,lon order
+# EPSG:3067 is east,north order (projected)
+srid.3067.latLon=false
+srid.3067.proj4=+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
+# Let hakunapi know that EPSG:4258 is lat,lon order (+ degrees)
 srid.4258.latLon=true
+srid.4258.degrees=true
 
 # Instead of loading PostGIS source drivers (the default) allow and load only GpkgSimpleSource
 db.classes=fi.nls.hakunapi.source.gpkg.GpkgSimpleSource

--- a/examples/finnish_admin_units/administrative_areas.properties
+++ b/examples/finnish_admin_units/administrative_areas.properties
@@ -20,6 +20,11 @@ servers.dev.description=Development server
 formats=json,html,csv
 formats.json.type=json
 formats.html.type=html
+# HTML tile layer configuration per SRID
+formats.html.3067.tileUrl=https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/taustakartta/default/ETRS-TM35FIN/{z}/{y}/{x}.png?api-key=7cd2ddae-9f2e-481c-99d0-404e7bc7a0b2
+formats.html.3067.tileAttribution=&copy; <a href="https://www.nls.fi">National Land Survey of Finland</a>
+formats.html.3067.tileOriginX=-548576
+formats.html.3067.tileOriginY=8388608
 formats.csv.type=csv
 #formats.geojson.forceLonLat=true
 getfeatures.limit.default=1000

--- a/src/hakunapi-crs-properties/src/main/java/fi/nls/hakunapi/crs/properties/PropertiesCRSRegistry.java
+++ b/src/hakunapi-crs-properties/src/main/java/fi/nls/hakunapi/crs/properties/PropertiesCRSRegistry.java
@@ -19,6 +19,9 @@ public class PropertiesCRSRegistry implements CRSRegistry {
 
     @Override
     public SRIDCode detect(Properties config, int srid) {
+        if (SRIDCode.isKnown(srid)) {
+            return SRIDCode.getKnown(srid);
+        }
         String latLonStr = config.getProperty("srid." + srid + ".latLon", "false");
         String degreesStr = config.getProperty("srid." + srid + ".degrees", "false");
         String dimensionStr = config.getProperty("srid." + srid + ".geometryDimension", "XY");


### PR DESCRIPTION
PropertiesCRSRegistry.detect() doesn't respect hardcoded known SRIDs (84, 4326). Registry always parses config properties, ignoring SRIDCode.isKnown() check. For 84/4326 with no config entry, applies default degrees=false, "overriding" hardcoded degrees=true for example.

PropertiesCRSRegistry.detect() now checks SRIDCode.isKnown(srid) first. Returns hardcoded instance directly if known, skips config parsing entirely.

**Workaround** in 1.7.x:
Configure manually
```
srid.84.degrees=true
srid.84.latLon=false
srid.4326.degrees=true
srid.4326.latLon=true
```

Additionally fix examples:
* Added `srid.4258.degrees=true`
* `formats.html.<srid>.*` configuration for HTML
* `srid.<srid>.proj4=` metadata

