### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ For a full list of changes see: https://github.com/nlsfi/hakunapi/milestone/17
 ### Library updates
 
 - `org.postgresql:postgresql` 42.7.10 → 42.7.11
-- `org.apache.logging.log4j:log4j-core` 2.25.3 → 2.25.4
+- `org.apache.logging.log4j:log4j-core` 2.25.3 → 2.26.0
+- `org.geotools` 34.2 → 35.0
+- `org.slf4j:slf4j-api` 1.7.25 → 2.0.18 (log4j binding switched `log4j-slf4j-impl` → `log4j-slf4j2-impl`)
+- `com.zaxxer:HikariCP` 4.0.3 → 7.1.0
+- `com.github.ben-manes.caffeine:caffeine` 2.9.3 → 3.2.4
+- `org.xerial:sqlite-jdbc` 3.47.0.0 → 3.53.2.0
 
 ## < 1.7.1
 

--- a/docs/overview/modules.md
+++ b/docs/overview/modules.md
@@ -72,30 +72,30 @@ The table below lists all direct third-party dependencies declared in the Hakuna
 | Library | Version | Purpose | Notes |
 | --- | --- | --- | --- |
 | JTS Topology Suite | 1.20.0 | Geometry model, spatial predicates | |
-| GeoTools | 34.2 | proj-gt: `gt-epsg-hsql` provides EPSG CRS database (HSQL-backed) for CRS definitions and reprojection | **To consider:** hakunapi-proj-proj (PROJ) [Issue #143](https://github.com/nlsfi/hakunapi/issues/143) to replace hakunapi-proj-gt for CRS definitions and reprojection? |
+| GeoTools | 35.0 | proj-gt: `gt-epsg-hsql` provides EPSG CRS database (HSQL-backed) for CRS definitions and reprojection | **To consider:** hakunapi-proj-proj (PROJ) [Issue #143](https://github.com/nlsfi/hakunapi/issues/143) to replace hakunapi-proj-gt for CRS definitions and reprojection? |
 
 #### Database connectivity
 
 | Library | Version | Purpose | Notes |
 | --- | --- | --- | --- |
-| HikariCP | 4.0.3 | JDBC connection pool | 4.0.3 is the last Java 8 release; current line is **7.x** |
+| HikariCP | 7.1.0 | JDBC connection pool | |
 | PostgreSQL JDBC | 42.7.11 | PostgreSQL / PostGIS JDBC driver for source-postgis | Try to stay up to date |
-| SQLite JDBC | 3.47.0.0 | SQLite JDBC for reading GeoPackage files for source-gpkg | |
+| SQLite JDBC | 3.53.2.0 | SQLite JDBC for reading GeoPackage files for source-gpkg | |
 
 #### Output formats and parsing
 
 | Library | Version | Purpose | Notes |
 | --- | --- | --- | --- |
 | FreeMarker | 2.3.33 | HTML template engine for HTML outputs | |
-| Caffeine | 2.9.3 | In-memory caching | Caffeine **3.x** targets Java 11+; no known reason to stay on 2.9. |
+| Caffeine | 3.2.4 | In-memory caching | |
 | ANTLR 4 runtime | 4.13.2 | Runtime for the ANTLR-generated CQL2 parser | |
 
 #### Logging and telemetry
 
 | Library | Version | Purpose | Notes |
 | --- | --- | --- | --- |
-| SLF4J | 1.7.25 | Logging facade | SLF4J **2.x** is the current line (and Log4j 2.25 supports it.) |
-| Log4j 2 | 2.25.4 | Logging implementation: API, core, SLF4J bridge, and Jakarta servlet lifecycle integration | |
+| SLF4J | 2.0.18 | Logging facade | |
+| Log4j 2 | 2.26.0 | Logging implementation: API, core, SLF4J 2 bridge (`log4j-slf4j2-impl`), and Jakarta servlet lifecycle integration | |
 
 #### Testing
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,16 +44,16 @@
 		<jackson-annotations.version>2.21</jackson-annotations.version>
 		<swagger.version>2.2.42</swagger.version>
 		<jts.version>1.20.0</jts.version>
-		<hikari.version>4.0.3</hikari.version>
-		<slf4j.version>1.7.25</slf4j.version>
-		<log4j.version>2.25.4</log4j.version>
+		<hikari.version>7.1.0</hikari.version>
+		<slf4j.version>2.0.18</slf4j.version>
+		<log4j.version>2.26.0</log4j.version>
 		<pgjdbc.version>42.7.11</pgjdbc.version>
-		<geotools.version>34.2</geotools.version>
+		<geotools.version>35.0</geotools.version>
 		<junit.version>4.13.2</junit.version>
 		<mockito.version>4.11.0</mockito.version>
 		<cyclonedx.version>2.9.1</cyclonedx.version>
 	    <json-path.version>2.9.0</json-path.version>
-	    <caffeine.version>2.9.3</caffeine.version>
+	    <caffeine.version>3.2.4</caffeine.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>21</java.version>
 		<maven.compiler.release>${java.version}</maven.compiler.release>
@@ -206,7 +206,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-slf4j-impl</artifactId>
+				<artifactId>log4j-slf4j2-impl</artifactId>
 				<version>${log4j.version}</version>
 			</dependency>
 			<dependency>
@@ -238,6 +238,11 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.13.0</version>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-war-plugin</artifactId>

--- a/src/hakunapi-gpkg/pom.xml
+++ b/src/hakunapi-gpkg/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>hakunapi-gpkg</artifactId>
 
     <properties>
-        <sqlite-jdbc.version>3.47.0.0</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.53.2.0</sqlite-jdbc.version>
     </properties>
 
     <repositories>

--- a/src/hakunapi-telemetry/pom.xml
+++ b/src/hakunapi-telemetry/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/webapp-jakarta/hakunapi-simple-webapp-jakarta/pom.xml
+++ b/webapp-jakarta/hakunapi-simple-webapp-jakarta/pom.xml
@@ -91,7 +91,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Related to https://github.com/nlsfi/hakunapi/issues/189

Update to GeoTools 35.0 and align supporting dependencies to their latest stable releases:

- geotools 34.2 -> 35.0
- slf4j-api 1.7.25 -> 2.0.18
- HikariCP 4.0.3 -> 7.1.0
- caffeine 2.9.3 -> 3.2.4
- sqlite-jdbc 3.47.0.0 -> 3.53.2.0
- log4j 2.25.4 -> 2.26.0

SLF4J 2.x requires the slf4j2 Log4j binding, so swap log4j-slf4j-impl -> log4j-slf4j2-impl in the root, telemetry, and webapp-jakarta poms. Update CHANGELOG.md and docs/overview/modules.md to match.